### PR TITLE
Eeprom Revision

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -15,6 +15,7 @@ Dnominal
 Doxyfile
 Doxygen
 eep
+eeprom
 emoji
 endif
 endl

--- a/src/Devices/EEPROM_TC.cpp
+++ b/src/Devices/EEPROM_TC.cpp
@@ -15,138 +15,151 @@ EEPROM_TC* EEPROM_TC::instance() {
 }
 
 //  instance methods
-/**
- * Constructor sets pins, dimensions, and shows splash screen
- */
 EEPROM_TC::EEPROM_TC() {
+}
+
+double EEPROM_TC::eepromReadDouble(int address) {
+  double value = 0.0;
+  byte* p = (byte*)(void*)&value;
+  for (int i = 0; i < sizeof(value); i++) {
+    *p++ = EEPROM.read(address++);
+  }
+  return value;
+}
+
+void EEPROM_TC::eepromWriteDouble(int address, double value) {
+  byte* p = (byte*)(void*)&value;
+  for (int i = 0; i < sizeof(value); i++) {
+    EEPROM.update(address++, *p++);
+  }
 }
 
 // getter methods
 double EEPROM_TC::getPH() {
-  return EEPROM.read(PH_ADDRESS);
+  return eepromReadDouble(PH_ADDRESS);
 }
 double EEPROM_TC::getTemp() {
-  return EEPROM.read(TEMP_ADDRESS);
+  return eepromReadDouble(TEMP_ADDRESS);
 }
 double EEPROM_TC::getTankID() {
-  return EEPROM.read(TANK_ID_ADDRESS);
+  return eepromReadDouble(TANK_ID_ADDRESS);
 }
 double EEPROM_TC::getCorrectedTemp() {
-  return EEPROM.read(TEMP_CORR_ADDRESS);
+  return eepromReadDouble(TEMP_CORR_ADDRESS);
 }
 double EEPROM_TC::getKP() {
-  return EEPROM.read(KP_ADDRESS);
+  return eepromReadDouble(KP_ADDRESS);
 }
 double EEPROM_TC::getKI() {
-  return EEPROM.read(KI_ADDRESS);
+  return eepromReadDouble(KI_ADDRESS);
 }
 double EEPROM_TC::getKD() {
-  return EEPROM.read(KD_ADDRESS);
+  return eepromReadDouble(KD_ADDRESS);
 }
 double EEPROM_TC::getMac() {  // See issue #57 about this function
-  return EEPROM.read(MAC_ADDRESS);
+  return eepromReadDouble(MAC_ADDRESS);
 }
 double EEPROM_TC::getHeat() {
-  return EEPROM.read(HEAT_ADDRESS);
+  return eepromReadDouble(HEAT_ADDRESS);
 }
 double EEPROM_TC::getAmplitude() {
-  return EEPROM.read(AMPLITUDE_ADDRESS);
+  return eepromReadDouble(AMPLITUDE_ADDRESS);
 }
 double EEPROM_TC::getFrequency() {
-  return EEPROM.read(FREQUENCY_ADDRESS);
+  return eepromReadDouble(FREQUENCY_ADDRESS);
 }
 double EEPROM_TC::getGranularity() {
-  return EEPROM.read(GRANULARITY_ADDRESS);
+  return eepromReadDouble(GRANULARITY_ADDRESS);
 }
 double EEPROM_TC::getMaxDataAge() {
-  return EEPROM.read(MAX_DATA_AGE_ADDRESS);
+  return eepromReadDouble(MAX_DATA_AGE_ADDRESS);
 }
 double EEPROM_TC::getPHSeriesSize() {
-  return EEPROM.read(PH_SERIES_SIZE_ADDRESS);
+  return eepromReadDouble(PH_SERIES_SIZE_ADDRESS);
 }
 double EEPROM_TC::getPHSeriesPointer() {
-  return EEPROM.read(PH_SERIES_POINTER_ADDRESS);
+  return eepromReadDouble(PH_SERIES_POINTER_ADDRESS);
 }
 double EEPROM_TC::getTempSeriesSize() {
-  return EEPROM.read(TEMP_SERIES_SIZE_ADDRESS);
+  return eepromReadDouble(TEMP_SERIES_SIZE_ADDRESS);
 }
 double EEPROM_TC::getTempSeriesPointer() {
-  return EEPROM.read(TEMP_SERIES_POINTER_ADDRESS);
+  return eepromReadDouble(TEMP_SERIES_POINTER_ADDRESS);
 }
 double EEPROM_TC::getPHInterval() {
-  return EEPROM.read(PH_INTERVAL_ADDRESS);
+  return eepromReadDouble(PH_INTERVAL_ADDRESS);
 }
 double EEPROM_TC::getPHDelay() {
-  return EEPROM.read(PH_DELAY_ADDRESS);
+  return eepromReadDouble(PH_DELAY_ADDRESS);
 }
 double EEPROM_TC::getTempInterval() {
-  return EEPROM.read(TEMP_INTERVAL_ADDRESS);
+  return eepromReadDouble(TEMP_INTERVAL_ADDRESS);
 }
 double EEPROM_TC::getTempDelay() {
-  return EEPROM.read(TEMP_DELAY_ADDRESS);
+  return eepromReadDouble(TEMP_DELAY_ADDRESS);
 }
 
 // setter methods
 void EEPROM_TC::setPH(double value) {
-  EEPROM.update(PH_ADDRESS, value);
+  eepromWriteDouble(PH_ADDRESS, value);
 }
 void EEPROM_TC::setTemp(double value) {
-  EEPROM.update(TEMP_ADDRESS, value);
+  eepromWriteDouble(TEMP_ADDRESS, value);
 }
 void EEPROM_TC::setTankID(double value) {
-  EEPROM.update(TANK_ID_ADDRESS, value);
+  eepromWriteDouble(TANK_ID_ADDRESS, value);
 }
 void EEPROM_TC::setCorrectedTemp(double value) {
-  EEPROM.update(TEMP_CORR_ADDRESS, value);
+  eepromWriteDouble(TEMP_CORR_ADDRESS, value);
 }
 void EEPROM_TC::setKP(double value) {
-  EEPROM.update(KP_ADDRESS, value);
+  eepromWriteDouble(KP_ADDRESS, value);
 }
 void EEPROM_TC::setKI(double value) {
-  EEPROM.update(KI_ADDRESS, value);
+  eepromWriteDouble(KI_ADDRESS, value);
 }
 void EEPROM_TC::setKD(double value) {
-  EEPROM.update(KD_ADDRESS, value);
+  eepromWriteDouble(KD_ADDRESS, value);
 }
 void EEPROM_TC::setMac(double value) {
-  EEPROM.update(MAC_ADDRESS, value);
-}  // Not used?
+  eepromWriteDouble(MAC_ADDRESS, value);
+}
 void EEPROM_TC::setHeat(double value) {
-  EEPROM.update(HEAT_ADDRESS, value);
+  eepromWriteDouble(HEAT_ADDRESS, value);
 }
 void EEPROM_TC::setAmplitude(double value) {
-  EEPROM.update(AMPLITUDE_ADDRESS, value);
+  eepromWriteDouble(AMPLITUDE_ADDRESS, value);
 }
 void EEPROM_TC::setFrequency(double value) {
-  EEPROM.update(FREQUENCY_ADDRESS, value);
+  eepromWriteDouble(FREQUENCY_ADDRESS, value);
 }
 void EEPROM_TC::setGranularity(double value) {
-  EEPROM.update(GRANULARITY_ADDRESS, value);
+  eepromWriteDouble(GRANULARITY_ADDRESS, value);
 }
 void EEPROM_TC::setMaxDataAge(double value) {
-  EEPROM.update(MAX_DATA_AGE_ADDRESS, value);
+  eepromWriteDouble(MAX_DATA_AGE_ADDRESS, value);
 }
 void EEPROM_TC::setPHSeriesSize(double value) {
-  EEPROM.update(PH_SERIES_SIZE_ADDRESS, value);
+  eepromWriteDouble(PH_SERIES_SIZE_ADDRESS, value);
 }
 void EEPROM_TC::setPHSeriesPointer(double value) {
-  EEPROM.update(PH_SERIES_POINTER_ADDRESS, value);
+  eepromWriteDouble(PH_SERIES_POINTER_ADDRESS, value);
 }
 void EEPROM_TC::setTempSeriesSize(double value) {
-  EEPROM.update(TEMP_SERIES_SIZE_ADDRESS, value);
+  eepromWriteDouble(TEMP_SERIES_SIZE_ADDRESS, value);
 }
 void EEPROM_TC::setTempSeriesPointer(double value) {
-  EEPROM.update(TEMP_SERIES_POINTER_ADDRESS, value);
+  eepromWriteDouble(TEMP_SERIES_POINTER_ADDRESS, value);
 }
 void EEPROM_TC::setPHInterval(double value) {
-  EEPROM.update(PH_INTERVAL_ADDRESS, value);
+  eepromWriteDouble(PH_INTERVAL_ADDRESS, value);
 }
 void EEPROM_TC::setPHDelay(double value) {
-  EEPROM.update(PH_DELAY_ADDRESS, value);
+  eepromWriteDouble(PH_DELAY_ADDRESS, value);
 }
 void EEPROM_TC::setTempInterval(double value) {
-  EEPROM.update(TEMP_INTERVAL_ADDRESS, value);
+  eepromWriteDouble(TEMP_INTERVAL_ADDRESS, value);
 }
 void EEPROM_TC::setTempDelay(double value) {
-  EEPROM.update(TEMP_DELAY_ADDRESS, value);
+  eepromWriteDouble(TEMP_DELAY_ADDRESS, value);
 }

--- a/src/Devices/EEPROM_TC.h
+++ b/src/Devices/EEPROM_TC.h
@@ -54,6 +54,10 @@ public:
   void setTempInterval(double value);
   void setTempDelay(double value);
 
+  // read and write
+  double eepromReadDouble(int address);
+  void eepromWriteDouble(int address, double value);
+
 private:
   // class variables
   static EEPROM_TC* _instance;

--- a/test/EEPROM.cpp
+++ b/test/EEPROM.cpp
@@ -14,7 +14,7 @@ unittest(Main) {
   assertEqual(singleton1, singleton2);
 }
 
-unittest(eeprom_Read_and_Write_Double) {
+unittest(EEPROM_Read_and_Write_Double) {
   EEPROM_TC* test = EEPROM_TC::instance();
   const int TEST_ADDRESS = 110;  // a couple addresses beyond stored data
 

--- a/test/EEPROM.cpp
+++ b/test/EEPROM.cpp
@@ -14,7 +14,7 @@ unittest(Main) {
   assertEqual(singleton1, singleton2);
 }
 
-unittest(EEPROM_Read_and_Write_Double) {
+unittest(eeprom_Read_and_Write_Double) {
   EEPROM_TC* test = EEPROM_TC::instance();
   const int TEST_ADDRESS = 110;  // a couple addresses beyond stored data
 

--- a/test/EEPROM.cpp
+++ b/test/EEPROM.cpp
@@ -14,151 +14,164 @@ unittest(Main) {
   assertEqual(singleton1, singleton2);
 }
 
+unittest(eeprom_Read_and_Write_Double) {
+  EEPROM_TC* test = EEPROM_TC::instance();
+  const int TEST_ADDRESS = 110;  // a couple addresses beyond stored data
+
+  // integer
+  test->eepromWriteDouble(TEST_ADDRESS, 10);
+  assertEqual(10, test->eepromReadDouble(TEST_ADDRESS));
+
+  // double
+  test->eepromWriteDouble(TEST_ADDRESS, 12.23);
+  assertEqual(12.23, test->eepromReadDouble(TEST_ADDRESS));
+}
+
 unittest(PH) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getPH(), 255);
-  singleton->setPH(3);
-  assertEqual(singleton->getPH(), 3);
+  assertNAN(singleton->getPH());
+  singleton->setPH(3.05);
+  assertEqual(3.05, singleton->getPH());
 }
 
 unittest(Temp) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getTemp(), 255);
+  assertNAN(singleton->getTemp());
   singleton->setTemp(4);
-  assertEqual(singleton->getTemp(), 4);
+  assertEqual(4, singleton->getTemp());
 }
 
 unittest(TankID) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getTankID(), 255);
+  assertNAN(singleton->getTankID());
   singleton->setTankID(5);
-  assertEqual(singleton->getTankID(), 5);
+  assertEqual(5, singleton->getTankID());
 }
 
 unittest(CorrectedTemp) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getCorrectedTemp(), 255);
+  assertNAN(singleton->getCorrectedTemp());
   singleton->setCorrectedTemp(6);
-  assertEqual(singleton->getCorrectedTemp(), 6);
+  assertEqual(6, singleton->getCorrectedTemp());
 }
 
 unittest(KP) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getKP(), 255);
+  assertNAN(singleton->getKP());
   singleton->setKP(7);
-  assertEqual(singleton->getKP(), 7);
+  assertEqual(7, singleton->getKP());
 }
 
 unittest(KI) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getKI(), 255);
+  assertNAN(singleton->getKI());
   singleton->setKI(8);
-  assertEqual(singleton->getKI(), 8);
+  assertEqual(8, singleton->getKI());
 }
 
 unittest(KD) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getKD(), 255);
+  assertNAN(singleton->getKD());
   singleton->setKD(9);
-  assertEqual(singleton->getKD(), 9);
+  assertEqual(9, singleton->getKD());
 }
 
 unittest(Mac) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getMac(), 255);
+  assertNAN(singleton->getMac());
   singleton->setMac(10);
-  assertEqual(singleton->getMac(), 10);
+  assertEqual(10, singleton->getMac());
 }
 
 unittest(Heat) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getHeat(), 255);
+  assertNAN(singleton->getHeat());
   singleton->setHeat(11);
-  assertEqual(singleton->getHeat(), 11);
+  assertEqual(11, singleton->getHeat());
 }
 
 unittest(Amplitude) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getAmplitude(), 255);
+  assertNAN(singleton->getAmplitude());
   singleton->setAmplitude(12);
-  assertEqual(singleton->getAmplitude(), 12);
+  assertEqual(12, singleton->getAmplitude());
 }
 
 unittest(Frequency) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getFrequency(), 255);
+  assertNAN(singleton->getFrequency());
   singleton->setFrequency(13);
-  assertEqual(singleton->getFrequency(), 13);
+  assertEqual(13, singleton->getFrequency());
 }
 
 unittest(Granularity) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getGranularity(), 255);
+  assertNAN(singleton->getGranularity());
   singleton->setGranularity(14);
-  assertEqual(singleton->getGranularity(), 14);
+  assertEqual(14, singleton->getGranularity());
 }
 
 unittest(MaxDataAge) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getMaxDataAge(), 255);
+  assertNAN(singleton->getMaxDataAge());
   singleton->setMaxDataAge(15);
-  assertEqual(singleton->getMaxDataAge(), 15);
+  assertEqual(15, singleton->getMaxDataAge());
 }
 
 unittest(PHSeriesSize) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getPHSeriesSize(), 255);
+  assertNAN(singleton->getPHSeriesSize());
   singleton->setPHSeriesSize(16);
-  assertEqual(singleton->getPHSeriesSize(), 16);
+  assertEqual(16, singleton->getPHSeriesSize());
 }
 
 unittest(PHSeriesPointer) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getPHSeriesPointer(), 255);
+  assertNAN(singleton->getPHSeriesPointer());
   singleton->setPHSeriesPointer(17);
-  assertEqual(singleton->getPHSeriesPointer(), 17);
+  assertEqual(17, singleton->getPHSeriesPointer());
 }
 
 unittest(TempSeriesSize) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getTempSeriesSize(), 255);
+  assertNAN(singleton->getTempSeriesSize());
   singleton->setTempSeriesSize(18);
-  assertEqual(singleton->getTempSeriesSize(), 18);
+  assertEqual(18, singleton->getTempSeriesSize());
 }
 
 unittest(TempSeriesPointer) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getTempSeriesPointer(), 255);
+  assertNAN(singleton->getTempSeriesPointer());
   singleton->setTempSeriesPointer(19);
-  assertEqual(singleton->getTempSeriesPointer(), 19);
+  assertEqual(19, singleton->getTempSeriesPointer());
 }
 
 unittest(PHInterval) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getPHInterval(), 255);
+  assertNAN(singleton->getPHInterval());
   singleton->setPHInterval(20);
-  assertEqual(singleton->getPHInterval(), 20);
+  assertEqual(20, singleton->getPHInterval());
 }
 
 unittest(PHDelay) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getPHDelay(), 255);
+  assertNAN(singleton->getPHDelay());
   singleton->setPHDelay(21);
-  assertEqual(singleton->getPHDelay(), 21);
+  assertEqual(21, singleton->getPHDelay());
 }
 
 unittest(TempInterval) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getTempInterval(), 255);
+  assertNAN(singleton->getTempInterval());
   singleton->setTempInterval(22);
-  assertEqual(singleton->getTempInterval(), 22);
+  assertEqual(22, singleton->getTempInterval());
 }
 
 unittest(TempDelay) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(singleton->getTempDelay(), 255);
+  assertNAN(singleton->getTempDelay());
   singleton->setTempDelay(23);
-  assertEqual(singleton->getTempDelay(), 23);
+  assertEqual(23, singleton->getTempDelay());
 }
 
 unittest_main()


### PR DESCRIPTION
The previous implementation of of EEPROM didn't properly convert double to uint8_t, whereas the original TankController did in EepromWriteDouble.ino and EepromReadDouble.ino. These changes should implement the previous functionality.