### PR TITLE
Revised EEPROM support

### DIFF
--- a/src/Devices/EEPROM_TC.cpp
+++ b/src/Devices/EEPROM_TC.cpp
@@ -1,5 +1,12 @@
 #include "Devices/EEPROM_TC.h"
 
+#ifdef MOCK_PINS_COUNT
+#include <cassert>   // to support testing
+#include <iostream>  // to support occasional debugging output
+#else
+#define assert(p) (void)0
+#endif
+
 //  class variables
 EEPROM_TC* EEPROM_TC::_instance = nullptr;
 
@@ -8,17 +15,21 @@ EEPROM_TC* EEPROM_TC::_instance = nullptr;
  * accessor for singleton
  */
 EEPROM_TC* EEPROM_TC::instance() {
-  if (!_instance) {
-    _instance = new EEPROM_TC();
+  if (_instance) {
+    return _instance;
   }
+  _instance = new EEPROM_TC_3();
+  if (_instance->isRightVersion()) {
+    return _instance;
+  }
+  delete _instance;
+  _instance = new EEPROM_TC_2();
   return _instance;
 }
 
 //  instance methods
-EEPROM_TC::EEPROM_TC() {
-}
-
 double EEPROM_TC::eepromReadDouble(int address) {
+  assert(address >= 0);
   double value = 0.0;
   byte* p = (byte*)(void*)&value;
   for (int i = 0; i < sizeof(value); i++) {
@@ -28,138 +39,28 @@ double EEPROM_TC::eepromReadDouble(int address) {
 }
 
 void EEPROM_TC::eepromWriteDouble(int address, double value) {
+  assert(address >= 0);
   byte* p = (byte*)(void*)&value;
   for (int i = 0; i < sizeof(value); i++) {
     EEPROM.update(address++, *p++);
   }
 }
 
-// getter methods
-double EEPROM_TC::getPH() {
-  return eepromReadDouble(PH_ADDRESS);
-}
-double EEPROM_TC::getTemp() {
-  return eepromReadDouble(TEMP_ADDRESS);
-}
-double EEPROM_TC::getTankID() {
-  return eepromReadDouble(TANK_ID_ADDRESS);
-}
-double EEPROM_TC::getCorrectedTemp() {
-  return eepromReadDouble(TEMP_CORR_ADDRESS);
-}
-double EEPROM_TC::getKP() {
-  return eepromReadDouble(KP_ADDRESS);
-}
-double EEPROM_TC::getKI() {
-  return eepromReadDouble(KI_ADDRESS);
-}
-double EEPROM_TC::getKD() {
-  return eepromReadDouble(KD_ADDRESS);
-}
-double EEPROM_TC::getMac() {  // See issue #57 about this function
-  return eepromReadDouble(MAC_ADDRESS);
-}
-double EEPROM_TC::getHeat() {
-  return eepromReadDouble(HEAT_ADDRESS);
-}
-double EEPROM_TC::getAmplitude() {
-  return eepromReadDouble(AMPLITUDE_ADDRESS);
-}
-double EEPROM_TC::getFrequency() {
-  return eepromReadDouble(FREQUENCY_ADDRESS);
-}
-double EEPROM_TC::getGranularity() {
-  return eepromReadDouble(GRANULARITY_ADDRESS);
-}
-double EEPROM_TC::getMaxDataAge() {
-  return eepromReadDouble(MAX_DATA_AGE_ADDRESS);
-}
-double EEPROM_TC::getPHSeriesSize() {
-  return eepromReadDouble(PH_SERIES_SIZE_ADDRESS);
-}
-double EEPROM_TC::getPHSeriesPointer() {
-  return eepromReadDouble(PH_SERIES_POINTER_ADDRESS);
-}
-double EEPROM_TC::getTempSeriesSize() {
-  return eepromReadDouble(TEMP_SERIES_SIZE_ADDRESS);
-}
-double EEPROM_TC::getTempSeriesPointer() {
-  return eepromReadDouble(TEMP_SERIES_POINTER_ADDRESS);
-}
-double EEPROM_TC::getPHInterval() {
-  return eepromReadDouble(PH_INTERVAL_ADDRESS);
-}
-double EEPROM_TC::getPHDelay() {
-  return eepromReadDouble(PH_DELAY_ADDRESS);
-}
-double EEPROM_TC::getTempInterval() {
-  return eepromReadDouble(TEMP_INTERVAL_ADDRESS);
-}
-double EEPROM_TC::getTempDelay() {
-  return eepromReadDouble(TEMP_DELAY_ADDRESS);
+int EEPROM_TC::eepromReadInt(int address) {
+  assert(address >= 0);
+  int value = 0.0;
+  byte* p = (byte*)(void*)&value;
+  for (int i = 0; i < sizeof(value); i++) {
+    *p++ = EEPROM.read(address++);
+  }
+  return value;
 }
 
-// setter methods
-void EEPROM_TC::setPH(double value) {
-  eepromWriteDouble(PH_ADDRESS, value);
+void EEPROM_TC::eepromWriteInt(int address, int value) {
+  assert(address >= 0);
+  byte* p = (byte*)(void*)&value;
+  for (int i = 0; i < sizeof(value); i++) {
+    EEPROM.update(address++, *p++);
+  }
 }
-void EEPROM_TC::setTemp(double value) {
-  eepromWriteDouble(TEMP_ADDRESS, value);
-}
-void EEPROM_TC::setTankID(double value) {
-  eepromWriteDouble(TANK_ID_ADDRESS, value);
-}
-void EEPROM_TC::setCorrectedTemp(double value) {
-  eepromWriteDouble(TEMP_CORR_ADDRESS, value);
-}
-void EEPROM_TC::setKP(double value) {
-  eepromWriteDouble(KP_ADDRESS, value);
-}
-void EEPROM_TC::setKI(double value) {
-  eepromWriteDouble(KI_ADDRESS, value);
-}
-void EEPROM_TC::setKD(double value) {
-  eepromWriteDouble(KD_ADDRESS, value);
-}
-void EEPROM_TC::setMac(double value) {
-  eepromWriteDouble(MAC_ADDRESS, value);
-}
-void EEPROM_TC::setHeat(double value) {
-  eepromWriteDouble(HEAT_ADDRESS, value);
-}
-void EEPROM_TC::setAmplitude(double value) {
-  eepromWriteDouble(AMPLITUDE_ADDRESS, value);
-}
-void EEPROM_TC::setFrequency(double value) {
-  eepromWriteDouble(FREQUENCY_ADDRESS, value);
-}
-void EEPROM_TC::setGranularity(double value) {
-  eepromWriteDouble(GRANULARITY_ADDRESS, value);
-}
-void EEPROM_TC::setMaxDataAge(double value) {
-  eepromWriteDouble(MAX_DATA_AGE_ADDRESS, value);
-}
-void EEPROM_TC::setPHSeriesSize(double value) {
-  eepromWriteDouble(PH_SERIES_SIZE_ADDRESS, value);
-}
-void EEPROM_TC::setPHSeriesPointer(double value) {
-  eepromWriteDouble(PH_SERIES_POINTER_ADDRESS, value);
-}
-void EEPROM_TC::setTempSeriesSize(double value) {
-  eepromWriteDouble(TEMP_SERIES_SIZE_ADDRESS, value);
-}
-void EEPROM_TC::setTempSeriesPointer(double value) {
-  eepromWriteDouble(TEMP_SERIES_POINTER_ADDRESS, value);
-}
-void EEPROM_TC::setPHInterval(double value) {
-  eepromWriteDouble(PH_INTERVAL_ADDRESS, value);
-}
-void EEPROM_TC::setPHDelay(double value) {
-  eepromWriteDouble(PH_DELAY_ADDRESS, value);
-}
-void EEPROM_TC::setTempInterval(double value) {
-  eepromWriteDouble(TEMP_INTERVAL_ADDRESS, value);
-}
-void EEPROM_TC::setTempDelay(double value) {
-  eepromWriteDouble(TEMP_DELAY_ADDRESS, value);
-}
+

--- a/src/Devices/EEPROM_TC.cpp
+++ b/src/Devices/EEPROM_TC.cpp
@@ -19,16 +19,20 @@ EEPROM_TC* EEPROM_TC::_instance = nullptr;
 /**
  * accessor for singleton
  */
-EEPROM_TC* EEPROM_TC::instance() {
+EEPROM_TC* EEPROM_TC::instance(int version) {
   if (_instance) {
+    assert(_instance->getVersion() == version);
     return _instance;
   }
   _instance = new EEPROM_TC_3();
   if (_instance->isRightVersion()) {
-    return _instance;
+    if (_instance->getVersion() == version) {
+      return _instance;
+    }
   }
   delete _instance;
   _instance = new EEPROM_TC_2();
+  assert(_instance->getVersion() == version);
   return _instance;
 }
 

--- a/src/Devices/EEPROM_TC.cpp
+++ b/src/Devices/EEPROM_TC.cpp
@@ -63,4 +63,3 @@ void EEPROM_TC::eepromWriteInt(int address, int value) {
     EEPROM.update(address++, *p++);
   }
 }
-

--- a/src/Devices/EEPROM_TC.cpp
+++ b/src/Devices/EEPROM_TC.cpp
@@ -1,5 +1,10 @@
 #include "Devices/EEPROM_TC.h"
 
+#include <EEPROM.h>
+
+#include "Devices/EEPROM_TC_2.h"
+#include "Devices/EEPROM_TC_3.h"
+
 #ifdef MOCK_PINS_COUNT
 #include <cassert>   // to support testing
 #include <iostream>  // to support occasional debugging output

--- a/src/Devices/EEPROM_TC.cpp
+++ b/src/Devices/EEPROM_TC.cpp
@@ -21,18 +21,18 @@ EEPROM_TC* EEPROM_TC::_instance = nullptr;
  */
 EEPROM_TC* EEPROM_TC::instance(int version) {
   if (_instance) {
-    assert(_instance->getVersion() == version);
+    assert(version == 0 || _instance->getVersion() == version);
     return _instance;
   }
   _instance = new EEPROM_TC_3();
   if (_instance->isRightVersion()) {
-    if (_instance->getVersion() == version) {
+    if (version == 0 || _instance->getVersion() == version) {
       return _instance;
     }
   }
   delete _instance;
   _instance = new EEPROM_TC_2();
-  assert(_instance->getVersion() == version);
+  assert(version == 0 || _instance->getVersion() == version);
   return _instance;
 }
 

--- a/src/Devices/EEPROM_TC.h
+++ b/src/Devices/EEPROM_TC.h
@@ -8,83 +8,67 @@ public:
   // class methods
   static EEPROM_TC* instance();
 
+  // destructor
+  virtual ~EEPROM_TC() {}
+
   // accessor methods
-  double getPH();
-  double getTemp();
-  double getTankID();
-  double getCorrectedTemp();
-  double getKP();
-  double getKI();
-  double getKD();
-  double getMac();  // See issue #57 about this function
-  double getHeat();
-  double getAmplitude();
-  double getFrequency();
-  double getGranularity();
-  double getMaxDataAge();
-  double getPHSeriesSize();
-  double getPHSeriesPointer();
-  double getTempSeriesSize();
-  double getTempSeriesPointer();
-  double getPHInterval();
-  double getPHDelay();
-  double getTempInterval();
-  double getTempDelay();
+  virtual int getVersion() = 0;
+  virtual double getPH() = 0;
+  virtual double getTemp() = 0;
+  virtual int getTankID() = 0;
+  virtual double getCorrectedTemp() = 0;
+  virtual double getKP() = 0;
+  virtual double getKI() = 0;
+  virtual double getKD() = 0;
+  virtual double getMac() = 0;  // See issue #57 about this function
+  virtual bool getHeat() = 0;
+  virtual double getAmplitude() = 0;
+  virtual double getFrequency() = 0;
+  virtual double getGranularity() = 0;
+  virtual double getMaxDataAge() = 0;
+  virtual double getPHSeriesSize() = 0;
+  virtual double getPHSeriesPointer() = 0;
+  virtual double getTempSeriesSize() = 0;
+  virtual double getTempSeriesPointer() = 0;
+  virtual double getPHInterval() = 0;
+  virtual double getPHDelay() = 0;
+  virtual double getTempInterval() = 0;
+  virtual double getTempDelay() = 0;
 
   // setter methods
-  void setPH(double value);
-  void setTemp(double value);
-  void setTankID(double value);
-  void setCorrectedTemp(double value);
-  void setKP(double value);
-  void setKI(double value);
-  void setKD(double value);
-  void setMac(double value);
-  void setHeat(double value);
-  void setAmplitude(double value);
-  void setFrequency(double value);
-  void setGranularity(double value);
-  void setMaxDataAge(double value);
-  void setPHSeriesSize(double value);
-  void setPHSeriesPointer(double value);
-  void setTempSeriesSize(double value);
-  void setTempSeriesPointer(double value);
-  void setPHInterval(double value);
-  void setPHDelay(double value);
-  void setTempInterval(double value);
-  void setTempDelay(double value);
+  virtual void setVersion() = 0;
+  virtual void setPH(double value) = 0;
+  virtual void setTemp(double value) = 0;
+  virtual void setTankID(int value) = 0;
+  virtual void setCorrectedTemp(double value) = 0;
+  virtual void setKP(double value) = 0;
+  virtual void setKI(double value) = 0;
+  virtual void setKD(double value) = 0;
+  virtual void setMac(double value) = 0;
+  virtual void setHeat(bool value) = 0;
+  virtual void setAmplitude(double value) = 0;
+  virtual void setFrequency(double value) = 0;
+  virtual void setGranularity(double value) = 0;
+  virtual void setMaxDataAge(double value) = 0;
+  virtual void setPHSeriesSize(double value) = 0;
+  virtual void setPHSeriesPointer(double value) = 0;
+  virtual void setTempSeriesSize(double value) = 0;
+  virtual void setTempSeriesPointer(double value) = 0;
+  virtual void setPHInterval(double value) = 0;
+  virtual void setPHDelay(double value) = 0;
+  virtual void setTempInterval(double value) = 0;
+  virtual void setTempDelay(double value) = 0;
 
   // read and write
   double eepromReadDouble(int address);
   void eepromWriteDouble(int address, double value);
+  int eepromReadInt(int address);
+  void eepromWriteInt(int address, int value);
+
+protected:
+  virtual bool isRightVersion() = 0;
 
 private:
   // class variables
   static EEPROM_TC* _instance;
-
-  // instance variables
-  const int PH_ADDRESS = 0;
-  const int TEMP_ADDRESS = 4;
-  const int TANK_ID_ADDRESS = 8;
-  const int TEMP_CORR_ADDRESS = 12;
-  const int KP_ADDRESS = 20;
-  const int KI_ADDRESS = 28;
-  const int KD_ADDRESS = 36;
-  const int MAC_ADDRESS = 44;
-  const int HEAT_ADDRESS = 52;
-  const int AMPLITUDE_ADDRESS = 56;
-  const int FREQUENCY_ADDRESS = 60;
-  const int GRANULARITY_ADDRESS = 64;   // granularity for SD logging interval
-  const int MAX_DATA_AGE_ADDRESS = 68;  // max data age for SD card
-  const int PH_SERIES_SIZE_ADDRESS = 72;
-  const int PH_SERIES_POINTER_ADDRESS = 76;
-  const int TEMP_SERIES_SIZE_ADDRESS = 80;
-  const int TEMP_SERIES_POINTER_ADDRESS = 84;
-  const int PH_INTERVAL_ADDRESS = 88;
-  const int PH_DELAY_ADDRESS = 92;
-  const int TEMP_INTERVAL_ADDRESS = 96;
-  const int TEMP_DELAY_ADDRESS = 100;
-
-  // instance methods
-  EEPROM_TC();
 };

--- a/src/Devices/EEPROM_TC.h
+++ b/src/Devices/EEPROM_TC.h
@@ -9,7 +9,8 @@ public:
   static EEPROM_TC* instance();
 
   // destructor
-  virtual ~EEPROM_TC() {}
+  virtual ~EEPROM_TC() {
+  }
 
   // accessor methods
   virtual int getVersion() = 0;

--- a/src/Devices/EEPROM_TC.h
+++ b/src/Devices/EEPROM_TC.h
@@ -5,7 +5,8 @@
 class EEPROM_TC {
 public:
   // class methods
-  static EEPROM_TC* instance();
+  // return singleton (the current version by default)
+  static EEPROM_TC* instance(int version = 3);
 
   // destructor
   virtual ~EEPROM_TC() {

--- a/src/Devices/EEPROM_TC.h
+++ b/src/Devices/EEPROM_TC.h
@@ -6,7 +6,7 @@ class EEPROM_TC {
 public:
   // class methods
   // return singleton (the current version by default)
-  static EEPROM_TC* instance(int version = 3);
+  static EEPROM_TC* instance(int version = 0);
 
   // destructor
   virtual ~EEPROM_TC() {

--- a/src/Devices/EEPROM_TC.h
+++ b/src/Devices/EEPROM_TC.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <Arduino.h>
-#include <EEPROM.h>
 
 class EEPROM_TC {
 public:

--- a/src/Devices/EEPROM_TC_2.cpp
+++ b/src/Devices/EEPROM_TC_2.cpp
@@ -1,0 +1,146 @@
+#include "Devices/EEPROM_TC_2.h"
+
+#ifdef MOCK_PINS_COUNT
+#include <cassert>   // to support testing
+#include <iostream>  // to support occasional debugging output
+#else
+#define assert(p) (void)0
+#endif
+
+//  instance methods
+bool EEPROM_TC_2::isRightVersion() {
+  return true;  // we have no way of telling!
+}
+int EEPROM_TC_2::getVersion() {
+  return 2;  // we assume so!
+}
+
+// getter methods
+double EEPROM_TC_2::getPH() {
+  return eepromReadDouble(PH_ADDRESS);
+}
+double EEPROM_TC_2::getTemp() {
+  return eepromReadDouble(TEMP_ADDRESS);
+}
+int EEPROM_TC_2::getTankID() {
+  return eepromReadInt(TANK_ID_ADDRESS);
+}
+double EEPROM_TC_2::getCorrectedTemp() {
+  return eepromReadDouble(TEMP_CORR_ADDRESS);
+}
+double EEPROM_TC_2::getKP() {
+  return eepromReadDouble(KP_ADDRESS);
+}
+double EEPROM_TC_2::getKI() {
+  return eepromReadDouble(KI_ADDRESS);
+}
+double EEPROM_TC_2::getKD() {
+  return eepromReadDouble(KD_ADDRESS);
+}
+double EEPROM_TC_2::getMac() {  // See issue #57 about this function
+  return eepromReadDouble(MAC_ADDRESS);
+}
+bool EEPROM_TC_2::getHeat() {
+  return (bool)eepromReadInt(HEAT_ADDRESS);
+}
+double EEPROM_TC_2::getAmplitude() {
+  return eepromReadDouble(AMPLITUDE_ADDRESS);
+}
+double EEPROM_TC_2::getFrequency() {
+  return eepromReadDouble(FREQUENCY_ADDRESS);
+}
+double EEPROM_TC_2::getGranularity() {
+  return eepromReadDouble(GRANULARITY_ADDRESS);
+}
+double EEPROM_TC_2::getMaxDataAge() {
+  return eepromReadDouble(MAX_DATA_AGE_ADDRESS);
+}
+double EEPROM_TC_2::getPHSeriesSize() {
+  return eepromReadDouble(PH_SERIES_SIZE_ADDRESS);
+}
+double EEPROM_TC_2::getPHSeriesPointer() {
+  return eepromReadDouble(PH_SERIES_POINTER_ADDRESS);
+}
+double EEPROM_TC_2::getTempSeriesSize() {
+  return eepromReadDouble(TEMP_SERIES_SIZE_ADDRESS);
+}
+double EEPROM_TC_2::getTempSeriesPointer() {
+  return eepromReadDouble(TEMP_SERIES_POINTER_ADDRESS);
+}
+double EEPROM_TC_2::getPHInterval() {
+  return eepromReadDouble(PH_INTERVAL_ADDRESS);
+}
+double EEPROM_TC_2::getPHDelay() {
+  return eepromReadDouble(PH_DELAY_ADDRESS);
+}
+double EEPROM_TC_2::getTempInterval() {
+  return eepromReadDouble(TEMP_INTERVAL_ADDRESS);
+}
+double EEPROM_TC_2::getTempDelay() {
+  return eepromReadDouble(TEMP_DELAY_ADDRESS);
+}
+
+// setter methods
+void EEPROM_TC_2::setPH(double value) {
+  eepromWriteDouble(PH_ADDRESS, value);
+}
+void EEPROM_TC_2::setTemp(double value) {
+  eepromWriteDouble(TEMP_ADDRESS, value);
+}
+void EEPROM_TC_2::setTankID(int value) {
+  eepromWriteInt(TANK_ID_ADDRESS, value);
+}
+void EEPROM_TC_2::setCorrectedTemp(double value) {
+  eepromWriteDouble(TEMP_CORR_ADDRESS, value);
+}
+void EEPROM_TC_2::setKP(double value) {
+  eepromWriteDouble(KP_ADDRESS, value);
+}
+void EEPROM_TC_2::setKI(double value) {
+  eepromWriteDouble(KI_ADDRESS, value);
+}
+void EEPROM_TC_2::setKD(double value) {
+  eepromWriteDouble(KD_ADDRESS, value);
+}
+void EEPROM_TC_2::setMac(double value) {
+  eepromWriteDouble(MAC_ADDRESS, value);
+}
+void EEPROM_TC_2::setHeat(bool value) {
+  eepromWriteInt(HEAT_ADDRESS, (int)value);
+}
+void EEPROM_TC_2::setAmplitude(double value) {
+  eepromWriteDouble(AMPLITUDE_ADDRESS, value);
+}
+void EEPROM_TC_2::setFrequency(double value) {
+  eepromWriteDouble(FREQUENCY_ADDRESS, value);
+}
+void EEPROM_TC_2::setGranularity(double value) {
+  eepromWriteDouble(GRANULARITY_ADDRESS, value);
+}
+void EEPROM_TC_2::setMaxDataAge(double value) {
+  eepromWriteDouble(MAX_DATA_AGE_ADDRESS, value);
+}
+void EEPROM_TC_2::setPHSeriesSize(double value) {
+  eepromWriteDouble(PH_SERIES_SIZE_ADDRESS, value);
+}
+void EEPROM_TC_2::setPHSeriesPointer(double value) {
+  eepromWriteDouble(PH_SERIES_POINTER_ADDRESS, value);
+}
+void EEPROM_TC_2::setTempSeriesSize(double value) {
+  eepromWriteDouble(TEMP_SERIES_SIZE_ADDRESS, value);
+}
+void EEPROM_TC_2::setTempSeriesPointer(double value) {
+  eepromWriteDouble(TEMP_SERIES_POINTER_ADDRESS, value);
+}
+void EEPROM_TC_2::setPHInterval(double value) {
+  eepromWriteDouble(PH_INTERVAL_ADDRESS, value);
+}
+void EEPROM_TC_2::setPHDelay(double value) {
+  eepromWriteDouble(PH_DELAY_ADDRESS, value);
+}
+void EEPROM_TC_2::setTempInterval(double value) {
+  eepromWriteDouble(TEMP_INTERVAL_ADDRESS, value);
+}
+void EEPROM_TC_2::setTempDelay(double value) {
+  eepromWriteDouble(TEMP_DELAY_ADDRESS, value);
+}

--- a/src/Devices/EEPROM_TC_2.cpp
+++ b/src/Devices/EEPROM_TC_2.cpp
@@ -23,7 +23,7 @@ double EEPROM_TC_2::getTemp() {
   return eepromReadDouble(TEMP_ADDRESS);
 }
 int EEPROM_TC_2::getTankID() {
-  return eepromReadInt(TANK_ID_ADDRESS);
+  return (int)eepromReadDouble(TANK_ID_ADDRESS);
 }
 double EEPROM_TC_2::getCorrectedTemp() {
   return eepromReadDouble(TEMP_CORR_ADDRESS);
@@ -41,7 +41,7 @@ double EEPROM_TC_2::getMac() {  // See issue #57 about this function
   return eepromReadDouble(MAC_ADDRESS);
 }
 bool EEPROM_TC_2::getHeat() {
-  return (bool)eepromReadInt(HEAT_ADDRESS);
+  return (bool)eepromReadDouble(HEAT_ADDRESS);
 }
 double EEPROM_TC_2::getAmplitude() {
   return eepromReadDouble(AMPLITUDE_ADDRESS);
@@ -88,7 +88,7 @@ void EEPROM_TC_2::setTemp(double value) {
   eepromWriteDouble(TEMP_ADDRESS, value);
 }
 void EEPROM_TC_2::setTankID(int value) {
-  eepromWriteInt(TANK_ID_ADDRESS, value);
+  eepromWriteDouble(TANK_ID_ADDRESS, (double)value);
 }
 void EEPROM_TC_2::setCorrectedTemp(double value) {
   eepromWriteDouble(TEMP_CORR_ADDRESS, value);
@@ -106,7 +106,7 @@ void EEPROM_TC_2::setMac(double value) {
   eepromWriteDouble(MAC_ADDRESS, value);
 }
 void EEPROM_TC_2::setHeat(bool value) {
-  eepromWriteInt(HEAT_ADDRESS, (int)value);
+  eepromWriteDouble(HEAT_ADDRESS, (double)value);
 }
 void EEPROM_TC_2::setAmplitude(double value) {
   eepromWriteDouble(AMPLITUDE_ADDRESS, value);

--- a/src/Devices/EEPROM_TC_2.h
+++ b/src/Devices/EEPROM_TC_2.h
@@ -57,6 +57,9 @@ protected:
   virtual bool isRightVersion();
 
 private:
+  // NOTE BUG: many addresses provide for 4 bytes for a double
+  // this is wrong and is fixed in EEPROM_TC_3
+
   // instance variables from v0.197
   const int PH_ADDRESS = 0;          // 9.999
   const int TEMP_ADDRESS = 4;        // 99.99

--- a/src/Devices/EEPROM_TC_2.h
+++ b/src/Devices/EEPROM_TC_2.h
@@ -29,7 +29,8 @@ public:
   double getTempDelay();
 
   // setter methods
-  void setVersion() {} // Nothing to be done here!
+  void setVersion() {
+  }  // Nothing to be done here!
   void setPH(double value);
   void setTemp(double value);
   void setTankID(int value);

--- a/src/Devices/EEPROM_TC_2.h
+++ b/src/Devices/EEPROM_TC_2.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "Devices/EEPROM_TC.h"
+
+class EEPROM_TC_2 : public EEPROM_TC {
+public:
+  // accessor methods
+  int getVersion();
+  double getPH();
+  double getTemp();
+  int getTankID();
+  double getCorrectedTemp();
+  double getKP();
+  double getKI();
+  double getKD();
+  double getMac();  // See issue #57 about this function
+  bool getHeat();
+  double getAmplitude();
+  double getFrequency();
+  double getGranularity();
+  double getMaxDataAge();
+  double getPHSeriesSize();
+  double getPHSeriesPointer();
+  double getTempSeriesSize();
+  double getTempSeriesPointer();
+  double getPHInterval();
+  double getPHDelay();
+  double getTempInterval();
+  double getTempDelay();
+
+  // setter methods
+  void setVersion() {} // Nothing to be done here!
+  void setPH(double value);
+  void setTemp(double value);
+  void setTankID(int value);
+  void setCorrectedTemp(double value);
+  void setKP(double value);
+  void setKI(double value);
+  void setKD(double value);
+  void setMac(double value);
+  void setHeat(bool value);
+  void setAmplitude(double value);
+  void setFrequency(double value);
+  void setGranularity(double value);
+  void setMaxDataAge(double value);
+  void setPHSeriesSize(double value);
+  void setPHSeriesPointer(double value);
+  void setTempSeriesSize(double value);
+  void setTempSeriesPointer(double value);
+  void setPHInterval(double value);
+  void setPHDelay(double value);
+  void setTempInterval(double value);
+  void setTempDelay(double value);
+
+protected:
+  virtual bool isRightVersion();
+
+private:
+  // instance variables from v0.197
+  const int PH_ADDRESS = 0;          // 9.999
+  const int TEMP_ADDRESS = 4;        // 99.99
+  const int TANK_ID_ADDRESS = 8;     // 999
+  const int TEMP_CORR_ADDRESS = 12;  // 99.99
+  const int KP_ADDRESS = 20;         // double
+  const int KI_ADDRESS = 28;         // double
+  const int KD_ADDRESS = 36;         // double
+  const int MAC_ADDRESS = 44;        // 8 byte
+  const int HEAT_ADDRESS = 52;       // bool
+  // new with v0.2
+  const int AMPLITUDE_ADDRESS = 56;
+  const int FREQUENCY_ADDRESS = 60;
+  const int GRANULARITY_ADDRESS = 64;   // granularity for SD logging interval
+  const int MAX_DATA_AGE_ADDRESS = 68;  // max data age for SD card
+  const int PH_SERIES_SIZE_ADDRESS = 72;
+  const int PH_SERIES_POINTER_ADDRESS = 76;
+  const int TEMP_SERIES_SIZE_ADDRESS = 80;
+  const int TEMP_SERIES_POINTER_ADDRESS = 84;
+  const int PH_INTERVAL_ADDRESS = 88;
+  const int PH_DELAY_ADDRESS = 92;
+  const int TEMP_INTERVAL_ADDRESS = 96;
+  const int TEMP_DELAY_ADDRESS = 100;
+};

--- a/src/Devices/EEPROM_TC_3.cpp
+++ b/src/Devices/EEPROM_TC_3.cpp
@@ -1,0 +1,155 @@
+#include "Devices/EEPROM_TC_3.h"
+
+#ifdef MOCK_PINS_COUNT
+#include <cassert>   // to support testing
+#include <iostream>  // to support occasional debugging output
+#else
+#define assert(p) (void)0
+#endif
+
+//  instance methods
+bool EEPROM_TC_3::isRightVersion() {
+  int version = getVersion();
+  return version == -1 || version == 3;
+}
+void EEPROM_TC_3::setVersion() {
+  eepromWriteInt(VERSION_ADDRESS, 3);
+}
+
+// getter methods
+int EEPROM_TC_3::getVersion() {
+  int result = eepromReadInt(VERSION_ADDRESS);
+  if (result == -1) {
+    setVersion();
+    result = eepromReadInt(VERSION_ADDRESS);
+  }
+  return result;
+}
+double EEPROM_TC_3::getPH() {
+  return eepromReadDouble(PH_ADDRESS);
+}
+double EEPROM_TC_3::getTemp() {
+  return eepromReadDouble(TEMP_ADDRESS);
+}
+int EEPROM_TC_3::getTankID() {
+  return eepromReadInt(TANK_ID_ADDRESS);
+}
+double EEPROM_TC_3::getCorrectedTemp() {
+  return eepromReadDouble(TEMP_CORR_ADDRESS);
+}
+double EEPROM_TC_3::getKP() {
+  return eepromReadDouble(KP_ADDRESS);
+}
+double EEPROM_TC_3::getKI() {
+  return eepromReadDouble(KI_ADDRESS);
+}
+double EEPROM_TC_3::getKD() {
+  return eepromReadDouble(KD_ADDRESS);
+}
+double EEPROM_TC_3::getMac() {  // See issue #57 about this function
+  return eepromReadDouble(MAC_ADDRESS);
+}
+bool EEPROM_TC_3::getHeat() {
+  return (bool)eepromReadInt(HEAT_ADDRESS);
+}
+double EEPROM_TC_3::getAmplitude() {
+  return eepromReadDouble(AMPLITUDE_ADDRESS);
+}
+double EEPROM_TC_3::getFrequency() {
+  return eepromReadDouble(FREQUENCY_ADDRESS);
+}
+double EEPROM_TC_3::getGranularity() {
+  return eepromReadDouble(GRANULARITY_ADDRESS);
+}
+double EEPROM_TC_3::getMaxDataAge() {
+  return eepromReadDouble(MAX_DATA_AGE_ADDRESS);
+}
+double EEPROM_TC_3::getPHSeriesSize() {
+  return eepromReadDouble(PH_SERIES_SIZE_ADDRESS);
+}
+double EEPROM_TC_3::getPHSeriesPointer() {
+  return eepromReadDouble(PH_SERIES_POINTER_ADDRESS);
+}
+double EEPROM_TC_3::getTempSeriesSize() {
+  return eepromReadDouble(TEMP_SERIES_SIZE_ADDRESS);
+}
+double EEPROM_TC_3::getTempSeriesPointer() {
+  return eepromReadDouble(TEMP_SERIES_POINTER_ADDRESS);
+}
+double EEPROM_TC_3::getPHInterval() {
+  return eepromReadDouble(PH_INTERVAL_ADDRESS);
+}
+double EEPROM_TC_3::getPHDelay() {
+  return eepromReadDouble(PH_DELAY_ADDRESS);
+}
+double EEPROM_TC_3::getTempInterval() {
+  return eepromReadDouble(TEMP_INTERVAL_ADDRESS);
+}
+double EEPROM_TC_3::getTempDelay() {
+  return eepromReadDouble(TEMP_DELAY_ADDRESS);
+}
+
+// setter methods
+void EEPROM_TC_3::setPH(double value) {
+  eepromWriteDouble(PH_ADDRESS, value);
+}
+void EEPROM_TC_3::setTemp(double value) {
+  eepromWriteDouble(TEMP_ADDRESS, value);
+}
+void EEPROM_TC_3::setTankID(int value) {
+  eepromWriteInt(TANK_ID_ADDRESS, value);
+}
+void EEPROM_TC_3::setCorrectedTemp(double value) {
+  eepromWriteDouble(TEMP_CORR_ADDRESS, value);
+}
+void EEPROM_TC_3::setKP(double value) {
+  eepromWriteDouble(KP_ADDRESS, value);
+}
+void EEPROM_TC_3::setKI(double value) {
+  eepromWriteDouble(KI_ADDRESS, value);
+}
+void EEPROM_TC_3::setKD(double value) {
+  eepromWriteDouble(KD_ADDRESS, value);
+}
+void EEPROM_TC_3::setMac(double value) {
+  eepromWriteDouble(MAC_ADDRESS, value);
+}
+void EEPROM_TC_3::setHeat(bool value) {
+  eepromWriteInt(HEAT_ADDRESS, (int)value);
+}
+void EEPROM_TC_3::setAmplitude(double value) {
+  eepromWriteDouble(AMPLITUDE_ADDRESS, value);
+}
+void EEPROM_TC_3::setFrequency(double value) {
+  eepromWriteDouble(FREQUENCY_ADDRESS, value);
+}
+void EEPROM_TC_3::setGranularity(double value) {
+  eepromWriteDouble(GRANULARITY_ADDRESS, value);
+}
+void EEPROM_TC_3::setMaxDataAge(double value) {
+  eepromWriteDouble(MAX_DATA_AGE_ADDRESS, value);
+}
+void EEPROM_TC_3::setPHSeriesSize(double value) {
+  eepromWriteDouble(PH_SERIES_SIZE_ADDRESS, value);
+}
+void EEPROM_TC_3::setPHSeriesPointer(double value) {
+  eepromWriteDouble(PH_SERIES_POINTER_ADDRESS, value);
+}
+void EEPROM_TC_3::setTempSeriesSize(double value) {
+  eepromWriteDouble(TEMP_SERIES_SIZE_ADDRESS, value);
+}
+void EEPROM_TC_3::setTempSeriesPointer(double value) {
+  eepromWriteDouble(TEMP_SERIES_POINTER_ADDRESS, value);
+}
+void EEPROM_TC_3::setPHInterval(double value) {
+  eepromWriteDouble(PH_INTERVAL_ADDRESS, value);
+}
+void EEPROM_TC_3::setPHDelay(double value) {
+  eepromWriteDouble(PH_DELAY_ADDRESS, value);
+}
+void EEPROM_TC_3::setTempInterval(double value) {
+  eepromWriteDouble(TEMP_INTERVAL_ADDRESS, value);
+}
+void EEPROM_TC_3::setTempDelay(double value) {
+  eepromWriteDouble(TEMP_DELAY_ADDRESS, value);
+}

--- a/src/Devices/EEPROM_TC_3.cpp
+++ b/src/Devices/EEPROM_TC_3.cpp
@@ -10,6 +10,7 @@
 //  instance methods
 bool EEPROM_TC_3::isRightVersion() {
   int version = getVersion();
+  // the initial value in EEPROM is -1, so we are starting clean
   return version == -1 || version == 3;
 }
 void EEPROM_TC_3::setVersion() {
@@ -20,6 +21,7 @@ void EEPROM_TC_3::setVersion() {
 int EEPROM_TC_3::getVersion() {
   int result = eepromReadInt(VERSION_ADDRESS);
   if (result == -1) {
+    // the initial value in EEPROM is -1, so we are starting clean
     setVersion();
     result = eepromReadInt(VERSION_ADDRESS);
   }

--- a/src/Devices/EEPROM_TC_3.h
+++ b/src/Devices/EEPROM_TC_3.h
@@ -58,7 +58,7 @@ protected:
 
 private:
   // new with v0.3
-  const int VERSION_ADDRESS = 0;                    // 999
+  const int VERSION_ADDRESS = 0;  // 999
   // from v0.197
   const int TANK_ID_ADDRESS = VERSION_ADDRESS + 4;  // 999
   const int HEAT_ADDRESS = TANK_ID_ADDRESS + 4;     // bool

--- a/src/Devices/EEPROM_TC_3.h
+++ b/src/Devices/EEPROM_TC_3.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "Devices/EEPROM_TC.h"
+
+class EEPROM_TC_3 : public EEPROM_TC {
+public:
+public:
+  // accessor methods
+  int getVersion();
+  double getPH();
+  double getTemp();
+  int getTankID();
+  double getCorrectedTemp();
+  double getKP();
+  double getKI();
+  double getKD();
+  double getMac();  // See issue #57 about this function
+  bool getHeat();
+  double getAmplitude();
+  double getFrequency();
+  double getGranularity();
+  double getMaxDataAge();
+  double getPHSeriesSize();
+  double getPHSeriesPointer();
+  double getTempSeriesSize();
+  double getTempSeriesPointer();
+  double getPHInterval();
+  double getPHDelay();
+  double getTempInterval();
+  double getTempDelay();
+
+  // setter methods
+  void setVersion();
+  void setPH(double value);
+  void setTemp(double value);
+  void setTankID(int value);
+  void setCorrectedTemp(double value);
+  void setKP(double value);
+  void setKI(double value);
+  void setKD(double value);
+  void setMac(double value);
+  void setHeat(bool value);
+  void setAmplitude(double value);
+  void setFrequency(double value);
+  void setGranularity(double value);
+  void setMaxDataAge(double value);
+  void setPHSeriesSize(double value);
+  void setPHSeriesPointer(double value);
+  void setTempSeriesSize(double value);
+  void setTempSeriesPointer(double value);
+  void setPHInterval(double value);
+  void setPHDelay(double value);
+  void setTempInterval(double value);
+  void setTempDelay(double value);
+
+protected:
+  virtual bool isRightVersion();
+
+private:
+  // new with v0.3
+  const int VERSION_ADDRESS = 0;                    // 999
+  // from v0.197
+  const int TANK_ID_ADDRESS = VERSION_ADDRESS + 4;  // 999
+  const int HEAT_ADDRESS = TANK_ID_ADDRESS + 4;     // bool
+  const int PH_ADDRESS = HEAT_ADDRESS + 4;          // 9.999
+  const int TEMP_ADDRESS = PH_ADDRESS + 8;          // 99.99
+  const int TEMP_CORR_ADDRESS = TEMP_ADDRESS + 8;   // 99.99
+  const int KP_ADDRESS = TEMP_CORR_ADDRESS + 8;     // double
+  const int KI_ADDRESS = KP_ADDRESS + 8;            // double
+  const int KD_ADDRESS = KI_ADDRESS + 8;            // double
+  const int MAC_ADDRESS = KD_ADDRESS + 8;           // 8 byte
+  // new with v0.2
+  const int AMPLITUDE_ADDRESS = MAC_ADDRESS + 8;
+  const int FREQUENCY_ADDRESS = AMPLITUDE_ADDRESS + 8;
+  const int GRANULARITY_ADDRESS = FREQUENCY_ADDRESS + 8;     // granularity for SD logging interval
+  const int MAX_DATA_AGE_ADDRESS = GRANULARITY_ADDRESS + 8;  // max data age for SD card
+  const int PH_SERIES_SIZE_ADDRESS = MAX_DATA_AGE_ADDRESS + 8;
+  const int PH_SERIES_POINTER_ADDRESS = PH_SERIES_SIZE_ADDRESS + 8;
+  const int TEMP_SERIES_SIZE_ADDRESS = PH_SERIES_POINTER_ADDRESS + 8;
+  const int TEMP_SERIES_POINTER_ADDRESS = TEMP_SERIES_SIZE_ADDRESS + 8;
+  const int PH_INTERVAL_ADDRESS = TEMP_SERIES_POINTER_ADDRESS + 8;
+  const int PH_DELAY_ADDRESS = PH_INTERVAL_ADDRESS + 8;
+  const int TEMP_INTERVAL_ADDRESS = PH_DELAY_ADDRESS + 8;
+  const int TEMP_DELAY_ADDRESS = TEMP_INTERVAL_ADDRESS + 8;
+};

--- a/src/Devices/EEPROM_TC_3.h
+++ b/src/Devices/EEPROM_TC_3.h
@@ -60,6 +60,7 @@ private:
   // new with v0.3
   const int VERSION_ADDRESS = 0;  // 999
   // from v0.197
+  // NOTE: addition represents size of previous value
   const int TANK_ID_ADDRESS = VERSION_ADDRESS + 4;  // 999
   const int HEAT_ADDRESS = TANK_ID_ADDRESS + 4;     // bool
   const int PH_ADDRESS = HEAT_ADDRESS + 4;          // 9.999

--- a/test/EEPROM.cpp
+++ b/test/EEPROM.cpp
@@ -3,7 +3,13 @@
 
 #include "EEPROM_TC.h"
 
-unittest(Main) {
+unittest(version) {
+  // Test singleton
+  EEPROM_TC* eeprom = EEPROM_TC::instance();
+  assert(eeprom->getVersion() == 3);
+}
+
+unittest(singleton) {
   // Test singleton
   EEPROM_TC* singleton1 = nullptr;
   singleton1 = EEPROM_TC::instance();
@@ -16,7 +22,7 @@ unittest(Main) {
 
 unittest(eeprom_Read_and_Write_Double) {
   EEPROM_TC* test = EEPROM_TC::instance();
-  const int TEST_ADDRESS = 110;  // a couple addresses beyond stored data
+  const int TEST_ADDRESS = 240;  // a couple addresses beyond stored data
 
   // integer
   test->eepromWriteDouble(TEST_ADDRESS, 10);
@@ -43,7 +49,7 @@ unittest(Temp) {
 
 unittest(TankID) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertNAN(singleton->getTankID());
+  assertEqual(-1, singleton->getTankID());
   singleton->setTankID(5);
   assertEqual(5, singleton->getTankID());
 }
@@ -85,9 +91,11 @@ unittest(Mac) {
 
 unittest(Heat) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertNAN(singleton->getHeat());
-  singleton->setHeat(11);
-  assertEqual(11, singleton->getHeat());
+  assertTrue(singleton->getHeat());  // (bool)(-1)
+  singleton->setHeat(false);
+  assertFalse(singleton->getHeat());
+  singleton->setHeat(true);
+  assertTrue(singleton->getHeat());
 }
 
 unittest(Amplitude) {

--- a/test/EEPROM.cpp
+++ b/test/EEPROM.cpp
@@ -6,7 +6,7 @@
 unittest(version) {
   // Test singleton
   EEPROM_TC* eeprom = EEPROM_TC::instance();
-  assert(eeprom->getVersion() == 3);
+  assertEqual(3, eeprom->getVersion());
 }
 
 unittest(singleton) {

--- a/test/EEPROM2.cpp
+++ b/test/EEPROM2.cpp
@@ -22,7 +22,7 @@ unittest(singleton) {
 
 unittest(eeprom_Read_and_Write_Double) {
   EEPROM_TC* test = EEPROM_TC::instance(2);
-  const int TEST_ADDRESS = 240;  // a couple addresses beyond stored data
+  const int TEST_ADDRESS = 4000;  // beyond the end of our use
 
   // integer
   test->eepromWriteDouble(TEST_ADDRESS, 10);
@@ -45,6 +45,13 @@ unittest(Temp) {
   assertNAN(singleton->getTemp());
   singleton->setTemp(4);
   assertEqual(4, singleton->getTemp());
+}
+
+// Confirm that memory overlap bug exists (fixed in EEPROM3)
+unittest(writing_PH_should_corrupt_Temp) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  singleton->setPH(3.05);
+  assertNotEqual(4, singleton->getTemp());
 }
 
 unittest(TankID) {

--- a/test/EEPROM2.cpp
+++ b/test/EEPROM2.cpp
@@ -49,6 +49,7 @@ unittest(Temp) {
 
 // Confirm that memory overlap bug exists (fixed in EEPROM3)
 unittest(writing_PH_should_corrupt_Temp) {
+  assertEqual(4, singleton->getTemp());
   EEPROM_TC* singleton = EEPROM_TC::instance();
   singleton->setPH(3.05);
   assertNotEqual(4, singleton->getTemp());

--- a/test/EEPROM2.cpp
+++ b/test/EEPROM2.cpp
@@ -51,7 +51,6 @@ unittest(Temp) {
 unittest(writing_PH_should_corrupt_Temp) {
   EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertEqual(4, singleton->getTemp());
-  EEPROM_TC* singleton = EEPROM_TC::instance();
   singleton->setPH(3.05);
   assertNotEqual(4, singleton->getTemp());
 }

--- a/test/EEPROM2.cpp
+++ b/test/EEPROM2.cpp
@@ -3,25 +3,25 @@
 
 #include "EEPROM_TC.h"
 
-unittest(version) {
+unittest(version2) {
   // Test singleton
-  EEPROM_TC* eeprom = EEPROM_TC::instance();
-  assertEqual(3, eeprom->getVersion());
+  EEPROM_TC* eeprom = EEPROM_TC::instance(2);
+  assertEqual(2, eeprom->getVersion());
 }
 
 unittest(singleton) {
   // Test singleton
   EEPROM_TC* singleton1 = nullptr;
-  singleton1 = EEPROM_TC::instance();
+  singleton1 = EEPROM_TC::instance(2);
   assertNotNull(singleton1);
   EEPROM_TC* singleton2 = nullptr;
-  singleton2 = EEPROM_TC::instance();
+  singleton2 = EEPROM_TC::instance(2);
   assertNotNull(singleton2);
   assertEqual(singleton1, singleton2);
 }
 
 unittest(eeprom_Read_and_Write_Double) {
-  EEPROM_TC* test = EEPROM_TC::instance();
+  EEPROM_TC* test = EEPROM_TC::instance(2);
   const int TEST_ADDRESS = 240;  // a couple addresses beyond stored data
 
   // integer
@@ -34,63 +34,63 @@ unittest(eeprom_Read_and_Write_Double) {
 }
 
 unittest(PH) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getPH());
   singleton->setPH(3.05);
   assertEqual(3.05, singleton->getPH());
 }
 
 unittest(Temp) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getTemp());
   singleton->setTemp(4);
   assertEqual(4, singleton->getTemp());
 }
 
 unittest(TankID) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
-  assertEqual(-1, singleton->getTankID());
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
+  // Because the temperature (above) overwrites this field we can't check its default
   singleton->setTankID(5);
   assertEqual(5, singleton->getTankID());
 }
 
 unittest(CorrectedTemp) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getCorrectedTemp());
   singleton->setCorrectedTemp(6);
   assertEqual(6, singleton->getCorrectedTemp());
 }
 
 unittest(KP) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getKP());
   singleton->setKP(7);
   assertEqual(7, singleton->getKP());
 }
 
 unittest(KI) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getKI());
   singleton->setKI(8);
   assertEqual(8, singleton->getKI());
 }
 
 unittest(KD) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getKD());
   singleton->setKD(9);
   assertEqual(9, singleton->getKD());
 }
 
 unittest(Mac) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getMac());
   singleton->setMac(10);
   assertEqual(10, singleton->getMac());
 }
 
 unittest(Heat) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertTrue(singleton->getHeat());  // (bool)(-1)
   singleton->setHeat(false);
   assertFalse(singleton->getHeat());
@@ -99,84 +99,84 @@ unittest(Heat) {
 }
 
 unittest(Amplitude) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getAmplitude());
   singleton->setAmplitude(12);
   assertEqual(12, singleton->getAmplitude());
 }
 
 unittest(Frequency) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getFrequency());
   singleton->setFrequency(13);
   assertEqual(13, singleton->getFrequency());
 }
 
 unittest(Granularity) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getGranularity());
   singleton->setGranularity(14);
   assertEqual(14, singleton->getGranularity());
 }
 
 unittest(MaxDataAge) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getMaxDataAge());
   singleton->setMaxDataAge(15);
   assertEqual(15, singleton->getMaxDataAge());
 }
 
 unittest(PHSeriesSize) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getPHSeriesSize());
   singleton->setPHSeriesSize(16);
   assertEqual(16, singleton->getPHSeriesSize());
 }
 
 unittest(PHSeriesPointer) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getPHSeriesPointer());
   singleton->setPHSeriesPointer(17);
   assertEqual(17, singleton->getPHSeriesPointer());
 }
 
 unittest(TempSeriesSize) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getTempSeriesSize());
   singleton->setTempSeriesSize(18);
   assertEqual(18, singleton->getTempSeriesSize());
 }
 
 unittest(TempSeriesPointer) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getTempSeriesPointer());
   singleton->setTempSeriesPointer(19);
   assertEqual(19, singleton->getTempSeriesPointer());
 }
 
 unittest(PHInterval) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getPHInterval());
   singleton->setPHInterval(20);
   assertEqual(20, singleton->getPHInterval());
 }
 
 unittest(PHDelay) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getPHDelay());
   singleton->setPHDelay(21);
   assertEqual(21, singleton->getPHDelay());
 }
 
 unittest(TempInterval) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getTempInterval());
   singleton->setTempInterval(22);
   assertEqual(22, singleton->getTempInterval());
 }
 
 unittest(TempDelay) {
-  EEPROM_TC* singleton = EEPROM_TC::instance();
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertNAN(singleton->getTempDelay());
   singleton->setTempDelay(23);
   assertEqual(23, singleton->getTempDelay());

--- a/test/EEPROM2.cpp
+++ b/test/EEPROM2.cpp
@@ -49,6 +49,7 @@ unittest(Temp) {
 
 // Confirm that memory overlap bug exists (fixed in EEPROM3)
 unittest(writing_PH_should_corrupt_Temp) {
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertEqual(4, singleton->getTemp());
   EEPROM_TC* singleton = EEPROM_TC::instance();
   singleton->setPH(3.05);

--- a/test/EEPROM2a.cpp
+++ b/test/EEPROM2a.cpp
@@ -12,8 +12,13 @@
  * tests are based on a boot/reset contents.
  */
 unittest(getVersion2) {
-  for (int i = 0; i < 4; ++i) {
-    EEPROM.update(i, 1);
+  union {
+    double d;
+    uint8_t b[8];
+  } u;
+  u.d = 7.2;
+  for (int i = 0; i < 8; ++i) {
+    EEPROM.update(i, u.b[i]);
   }
   EEPROM_TC* eeprom = EEPROM_TC::instance();
   assertEqual(2, eeprom->getVersion());

--- a/test/EEPROM2a.cpp
+++ b/test/EEPROM2a.cpp
@@ -1,0 +1,22 @@
+#include <Arduino.h>
+#include <ArduinoUnitTests.h>
+#include <EEPROM.h>
+
+#include "EEPROM_TC.h"
+
+/*
+ * If the first four bytes aren't a valid version,
+ * then we use the legacy layout.
+ *
+ * This is in a separate test because the other
+ * tests are based on a boot/reset contents.
+ */
+unittest(getVersion2) {
+  for (int i = 0; i < 4; ++i) {
+    EEPROM.update(i, 1);
+  }
+  EEPROM_TC* eeprom = EEPROM_TC::instance();
+  assertEqual(2, eeprom->getVersion());
+}
+
+unittest_main()

--- a/test/EEPROM3.cpp
+++ b/test/EEPROM3.cpp
@@ -56,9 +56,8 @@ unittest(Temp) {
 
 // Confirm that memory overlap bug is fixed in EEPROM3
 unittest(writing_PH_should_corrupt_Temp) {
-  EEPROM_TC* singleton = EEPROM_TC::instance(2);
-  assertEqual(4, singleton->getTemp());
   EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertEqual(4, singleton->getTemp());
   singleton->setPH(3.05);
   assertEqual(4, singleton->getTemp());
 }

--- a/test/EEPROM3.cpp
+++ b/test/EEPROM3.cpp
@@ -22,7 +22,7 @@ unittest(singleton) {
 
 unittest(eeprom_Read_and_Write_Double) {
   EEPROM_TC* test = EEPROM_TC::instance();
-  const int TEST_ADDRESS = 240;  // a couple addresses beyond stored data
+  const int TEST_ADDRESS = 4000;  // beyond the end of our use
 
   // integer
   test->eepromWriteDouble(TEST_ADDRESS, 10);
@@ -51,6 +51,13 @@ unittest(Temp) {
   EEPROM_TC* singleton = EEPROM_TC::instance();
   assertNAN(singleton->getTemp());
   singleton->setTemp(4);
+  assertEqual(4, singleton->getTemp());
+}
+
+// Confirm that memory overlap bug is fixed in EEPROM3
+unittest(writing_PH_should_corrupt_Temp) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  singleton->setPH(3.05);
   assertEqual(4, singleton->getTemp());
 }
 

--- a/test/EEPROM3.cpp
+++ b/test/EEPROM3.cpp
@@ -1,0 +1,192 @@
+#include <Arduino.h>
+#include <ArduinoUnitTests.h>
+
+#include "EEPROM_TC.h"
+
+unittest(version) {
+  // Test singleton
+  EEPROM_TC* eeprom = EEPROM_TC::instance();
+  assertEqual(3, eeprom->getVersion());
+}
+
+unittest(singleton) {
+  // Test singleton
+  EEPROM_TC* singleton1 = nullptr;
+  singleton1 = EEPROM_TC::instance();
+  assertNotNull(singleton1);
+  EEPROM_TC* singleton2 = nullptr;
+  singleton2 = EEPROM_TC::instance();
+  assertNotNull(singleton2);
+  assertEqual(singleton1, singleton2);
+}
+
+unittest(eeprom_Read_and_Write_Double) {
+  EEPROM_TC* test = EEPROM_TC::instance();
+  const int TEST_ADDRESS = 240;  // a couple addresses beyond stored data
+
+  // integer
+  test->eepromWriteDouble(TEST_ADDRESS, 10);
+  assertEqual(10, test->eepromReadDouble(TEST_ADDRESS));
+
+  // double
+  test->eepromWriteDouble(TEST_ADDRESS, 12.23);
+  assertEqual(12.23, test->eepromReadDouble(TEST_ADDRESS));
+}
+
+unittest(eeprom_Read_and_Write_Int) {
+  EEPROM_TC* test = EEPROM_TC::instance();
+  const int TEST_ADDRESS = 240;  // a couple addresses beyond stored data
+  test->eepromWriteInt(TEST_ADDRESS, 20);
+  assertEqual(20, test->eepromReadInt(TEST_ADDRESS));
+}
+
+unittest(PH) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getPH());
+  singleton->setPH(3.05);
+  assertEqual(3.05, singleton->getPH());
+}
+
+unittest(Temp) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getTemp());
+  singleton->setTemp(4);
+  assertEqual(4, singleton->getTemp());
+}
+
+unittest(TankID) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertEqual(-1, singleton->getTankID());
+  singleton->setTankID(5);
+  assertEqual(5, singleton->getTankID());
+}
+
+unittest(CorrectedTemp) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getCorrectedTemp());
+  singleton->setCorrectedTemp(6);
+  assertEqual(6, singleton->getCorrectedTemp());
+}
+
+unittest(KP) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getKP());
+  singleton->setKP(7);
+  assertEqual(7, singleton->getKP());
+}
+
+unittest(KI) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getKI());
+  singleton->setKI(8);
+  assertEqual(8, singleton->getKI());
+}
+
+unittest(KD) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getKD());
+  singleton->setKD(9);
+  assertEqual(9, singleton->getKD());
+}
+
+unittest(Mac) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getMac());
+  singleton->setMac(10);
+  assertEqual(10, singleton->getMac());
+}
+
+unittest(Heat) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertTrue(singleton->getHeat());  // (bool)(-1)
+  singleton->setHeat(false);
+  assertFalse(singleton->getHeat());
+  singleton->setHeat(true);
+  assertTrue(singleton->getHeat());
+}
+
+unittest(Amplitude) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getAmplitude());
+  singleton->setAmplitude(12);
+  assertEqual(12, singleton->getAmplitude());
+}
+
+unittest(Frequency) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getFrequency());
+  singleton->setFrequency(13);
+  assertEqual(13, singleton->getFrequency());
+}
+
+unittest(Granularity) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getGranularity());
+  singleton->setGranularity(14);
+  assertEqual(14, singleton->getGranularity());
+}
+
+unittest(MaxDataAge) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getMaxDataAge());
+  singleton->setMaxDataAge(15);
+  assertEqual(15, singleton->getMaxDataAge());
+}
+
+unittest(PHSeriesSize) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getPHSeriesSize());
+  singleton->setPHSeriesSize(16);
+  assertEqual(16, singleton->getPHSeriesSize());
+}
+
+unittest(PHSeriesPointer) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getPHSeriesPointer());
+  singleton->setPHSeriesPointer(17);
+  assertEqual(17, singleton->getPHSeriesPointer());
+}
+
+unittest(TempSeriesSize) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getTempSeriesSize());
+  singleton->setTempSeriesSize(18);
+  assertEqual(18, singleton->getTempSeriesSize());
+}
+
+unittest(TempSeriesPointer) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getTempSeriesPointer());
+  singleton->setTempSeriesPointer(19);
+  assertEqual(19, singleton->getTempSeriesPointer());
+}
+
+unittest(PHInterval) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getPHInterval());
+  singleton->setPHInterval(20);
+  assertEqual(20, singleton->getPHInterval());
+}
+
+unittest(PHDelay) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getPHDelay());
+  singleton->setPHDelay(21);
+  assertEqual(21, singleton->getPHDelay());
+}
+
+unittest(TempInterval) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getTempInterval());
+  singleton->setTempInterval(22);
+  assertEqual(22, singleton->getTempInterval());
+}
+
+unittest(TempDelay) {
+  EEPROM_TC* singleton = EEPROM_TC::instance();
+  assertNAN(singleton->getTempDelay());
+  singleton->setTempDelay(23);
+  assertEqual(23, singleton->getTempDelay());
+}
+
+unittest_main()

--- a/test/EEPROM3.cpp
+++ b/test/EEPROM3.cpp
@@ -35,7 +35,7 @@ unittest(eeprom_Read_and_Write_Double) {
 
 unittest(eeprom_Read_and_Write_Int) {
   EEPROM_TC* test = EEPROM_TC::instance();
-  const int TEST_ADDRESS = 240;  // a couple addresses beyond stored data
+  const int TEST_ADDRESS = 4000;  // beyond the end of our use
   test->eepromWriteInt(TEST_ADDRESS, 20);
   assertEqual(20, test->eepromReadInt(TEST_ADDRESS));
 }

--- a/test/EEPROM3.cpp
+++ b/test/EEPROM3.cpp
@@ -56,6 +56,7 @@ unittest(Temp) {
 
 // Confirm that memory overlap bug is fixed in EEPROM3
 unittest(writing_PH_should_corrupt_Temp) {
+  EEPROM_TC* singleton = EEPROM_TC::instance(2);
   assertEqual(4, singleton->getTemp());
   EEPROM_TC* singleton = EEPROM_TC::instance();
   singleton->setPH(3.05);

--- a/test/EEPROM3.cpp
+++ b/test/EEPROM3.cpp
@@ -56,6 +56,7 @@ unittest(Temp) {
 
 // Confirm that memory overlap bug is fixed in EEPROM3
 unittest(writing_PH_should_corrupt_Temp) {
+  assertEqual(4, singleton->getTemp());
   EEPROM_TC* singleton = EEPROM_TC::instance();
   singleton->setPH(3.05);
   assertEqual(4, singleton->getTemp());

--- a/test/EEPROM3a.cpp
+++ b/test/EEPROM3a.cpp
@@ -1,0 +1,27 @@
+#include <Arduino.h>
+#include <ArduinoUnitTests.h>
+#include <EEPROM.h>
+
+#include "EEPROM_TC.h"
+
+/*
+ * If the first four bytes are a valid version,
+ * then we use that version (in this case, v3).
+ *
+ * This is in a separate test because the other
+ * tests are based on a boot/reset contents.
+ */
+unittest(getVersion3) {
+  union {
+    int i;
+    uint8_t b[4];
+  } u;
+  u.i = 3;
+  for (int i = 0; i < 4; ++i) {
+    EEPROM.update(i, u.b[i]);
+  }
+  EEPROM_TC* eeprom = EEPROM_TC::instance();
+  assertEqual(3, eeprom->getVersion());
+}
+
+unittest_main()


### PR DESCRIPTION
Refactored to avoid memory overlaps. Current behavior is to use old implementation if data exists, otherwise use the new implementation. We have tests for most conditions. The only unimplemented feature is an auto-migrate or reset and these can be considered as new feature requests.