### PR TITLE
Use TempProbe to get temperature

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -34,6 +34,7 @@ FONTSTYLE
 FONTWEIGHT
 Gemfile
 github
+globals
 godmode
 Google
 hh

--- a/src/Devices/TempProbe_TC.cpp
+++ b/src/Devices/TempProbe_TC.cpp
@@ -24,3 +24,26 @@ TempProbe_TC* TempProbe_TC::instance() {
 TempProbe_TC::TempProbe_TC() {
   thermo.begin(MAX31865_3WIRE);  // Start pt100 temperature probe with 3 wire configuration
 }
+
+/**
+ * getRunningAverage()
+ *
+ * Read the current temperature and return a running average
+ */
+
+double TempProbe_TC::getRunningAverage() {
+  double temp = this->getRawTemperature() + correction;
+  if (firstTime) {
+    for (int i = 0; i < HISTORY_SIZE; ++i) {
+      history[i] = temp;
+    }
+    firstTime = false;
+  }
+  historyIndex = (historyIndex + 1) % HISTORY_SIZE;
+  history[historyIndex] = temp;
+  double sum = 0.0;
+  for (int i = 0; i < HISTORY_SIZE; ++i) {
+    sum += history[i];
+  }
+  return sum / HISTORY_SIZE;
+}

--- a/src/Devices/TempProbe_TC.h
+++ b/src/Devices/TempProbe_TC.h
@@ -106,6 +106,13 @@ public:
     thermo.clearFault();
   }
 
+#ifdef MOCK_PINS_COUNT
+  // set a temperature in the mock
+  void setTemperature(float newTemp) {
+    thermo.setTemperature(newTemp);
+  }
+#endif
+
 private:
   //  Class variables
   static TempProbe_TC* _instance;

--- a/src/Devices/TempProbe_TC.h
+++ b/src/Devices/TempProbe_TC.h
@@ -94,9 +94,11 @@ public:
     return thermo.readRTD();
   }
 
-  float getTemperature() {
+  float getRawTemperature() {
     return thermo.temperature(RTDnominal, refResistor);
   }
+
+  double getRunningAverage();
 
   uint8_t readFault() {
     return thermo.readFault();
@@ -104,6 +106,10 @@ public:
 
   void clearFault() {
     thermo.clearFault();
+  }
+
+  void setCorrection(float value) {
+    correction = value;
   }
 
 #ifdef MOCK_PINS_COUNT
@@ -114,11 +120,18 @@ public:
 #endif
 
 private:
-  //  Class variables
+  //  Class variable
   static TempProbe_TC* _instance;
-  const int RTDnominal = 100;
-  const int refResistor = 430;
+
+  //  Instance variables
+  static const int RTDnominal = 100;
+  static const int refResistor = 430;
   Adafruit_MAX31865 thermo = Adafruit_MAX31865(45, 43, 41, 39);
+  bool firstTime = true;
+  static const int HISTORY_SIZE = 10;
+  double history[HISTORY_SIZE];
+  int historyIndex = 0;
+  double correction = 0.0;
 
   // Methods
   TempProbe_TC();

--- a/src/TankControllerLib.cpp
+++ b/src/TankControllerLib.cpp
@@ -124,7 +124,7 @@ void TankControllerLib::updateState() {
 
 /**
  * Public member function used to get the current state name.
- * This is primarioly used by testing.
+ * This is primarily used by testing.
  */
 
 String TankControllerLib::stateName() {

--- a/src/TankControllerLib.cpp
+++ b/src/TankControllerLib.cpp
@@ -106,15 +106,18 @@ void TankControllerLib::setup() {
 }
 
 /**
+ * Public member function used to get the current state name.
+ * This is primarioly used by testing.
+ */
+
+String TankControllerLib::stateName() {
+  return state->name();
+}
+
+/**
  * What is the current version?
  */
 const char *TankControllerLib::version() {
   log->print((const char *)F("TankControllerLib::version() = "), (const char *)TANK_CONTROLLER_VERSION);
   return TANK_CONTROLLER_VERSION;
 }
-
-#ifdef MOCK_PINS_COUNT
-bool TankControllerLibTest::isOnMainMenu() {
-  return state->isMainMenu();
-}
-#endif

--- a/src/TankControllerLib.cpp
+++ b/src/TankControllerLib.cpp
@@ -58,30 +58,19 @@ void TankControllerLib::blink() {
 }
 
 /**
- * Private member function called by UIState subclasses
- * Only updates if a new state is available to switch to
- */
-void TankControllerLib::updateState() {
-  if (nextState) {
-    assert(state != nextState);
-    delete state;
-    state = nextState;
-    nextState = nullptr;
-    state->start();
-  }
-}
-
-/**
  * Private member function called by loop
  * Handles keypresses
  */
 void TankControllerLib::handleUI() {
+  // std::cout << "TankControllerLib::handleUI() - " << state->name() << std::endl;
   char key = Keypad_TC::instance()->getKey();
   if (key != NO_KEY) {
     log->print(F("Keypad input: "), key);
+    // std::cout << "TankControllerLib::handleUI() - " << state->name() << "::handleKey(" << key << ")" << std::endl;
     state->handleKey(key);
   }
   updateState();
+  // std::cout << "TankControllerLib::handleUI() - " << state->name() << "::loop()" << std::endl;
   state->loop();
 }
 
@@ -90,8 +79,21 @@ void TankControllerLib::handleUI() {
  * It is called repeatedly while the board is on.
  */
 void TankControllerLib::loop() {
+  // std::cout << "TankControllerLib::loop() for " << newState->name() << std::endl;
   blink();  //  blink the on-board LED to show that we are running
   handleUI();
+}
+
+/**
+ * Set the next state
+ */
+void TankControllerLib::setNextState(UIState *newState, bool update) {
+  // std::cout << "TankControllerLib::setNextState() to " << newState->name() << std::endl;
+  assert(nextState == nullptr);
+  nextState = newState;
+  if (update) {
+    this->updateState();
+  }
 }
 
 /**
@@ -103,6 +105,21 @@ void TankControllerLib::setup() {
   setNextState(((UIState *)new MainMenu(this)));
   updateState();
   pinMode(LED_BUILTIN, OUTPUT);
+}
+
+/**
+ * Private member function called by UIState subclasses
+ * Only updates if a new state is available to switch to
+ */
+void TankControllerLib::updateState() {
+  if (nextState) {
+    // std::cout << "TankControllerLib::updateState() to " << nextState->name() << std::endl;
+    assert(state != nextState);
+    delete state;
+    state = nextState;
+    nextState = nullptr;
+    state->start();
+  }
 }
 
 /**

--- a/src/TankControllerLib.h
+++ b/src/TankControllerLib.h
@@ -14,14 +14,11 @@ public:
   static TankControllerLib* instance();
 
   // instance methods
-  void setup();
   void loop();
+  void setNextState(UIState* newState, bool update = false);
+  void setup();
   String stateName();
   const char* version();
-  virtual void setNextState(UIState* newState) {
-    assert(nextState == nullptr);
-    nextState = newState;
-  }
 
 protected:
   // class variables
@@ -40,15 +37,3 @@ protected:
   void handleUI();
   void updateState();
 };
-
-#ifdef MOCK_PINS_COUNT
-class TankControllerLibTest : public TankControllerLib {
-public:
-  void setNextState(UIState* newState) {
-    assert(nextState == nullptr);
-    nextState = newState;
-    updateState();
-  }
-  bool isOnMainMenu();
-};
-#endif

--- a/src/TankControllerLib.h
+++ b/src/TankControllerLib.h
@@ -16,6 +16,7 @@ public:
   // instance methods
   void setup();
   void loop();
+  String stateName();
   const char* version();
   virtual void setNextState(UIState* newState) {
     assert(nextState == nullptr);

--- a/src/UIState/CalibrationManagement.h
+++ b/src/UIState/CalibrationManagement.h
@@ -11,6 +11,9 @@ public:
   CalibrationManagement(TankControllerLib* tc) : UIState(tc) {
   }
   void handleKey(char key);
+  String name() {
+    return "CalibrationManagement";
+  }
   const char* prompt() {
     return "Cal Management  ";
   };

--- a/src/UIState/EnablePID.h
+++ b/src/UIState/EnablePID.h
@@ -11,6 +11,9 @@ public:
   EnablePID(TankControllerLib* tc) : UIState(tc) {
   }
   void handleKey(char key);
+  String name() {
+    return "EnablePID";
+  }
   const char* prompt() {
     return "Enable PID?     ";
   };

--- a/src/UIState/MainMenu.cpp
+++ b/src/UIState/MainMenu.cpp
@@ -15,7 +15,7 @@
 #include "SetTankID.h"
 #include "SetTempSetPoint.h"
 #include "SetTime.h"
-#include "TempProbe_TC.h"
+#include "Devices/TempProbe_TC.h"
 #include "TemperatureCalibration.h"
 
 /**

--- a/src/UIState/MainMenu.cpp
+++ b/src/UIState/MainMenu.cpp
@@ -1,6 +1,7 @@
 #include "MainMenu.h"
 
 #include "CalibrationManagement.h"
+#include "Devices/TempProbe_TC.h"
 #include "EnablePID.h"
 #include "PHCalibration.h"
 #include "PIDTuningMenu.h"
@@ -15,7 +16,6 @@
 #include "SetTankID.h"
 #include "SetTempSetPoint.h"
 #include "SetTime.h"
-#include "Devices/TempProbe_TC.h"
 #include "TemperatureCalibration.h"
 
 /**

--- a/src/UIState/MainMenu.cpp
+++ b/src/UIState/MainMenu.cpp
@@ -16,6 +16,7 @@
 #include "SetTempSetPoint.h"
 #include "SetTime.h"
 #include "TemperatureCalibration.h"
+#include "TempProbe_TC.h"
 
 /**
  * Branch to other states to handle various menu options
@@ -76,6 +77,10 @@ void MainMenu::handleKey(char key) {
   }
 }
 
+// show current temp and pH
 void MainMenu::loop() {
-  // show current temp and pH
+  TempProbe_TC *tempProbe = TempProbe_TC::instance();
+  char output[17];
+  sprintf(output, "Temp=%2.2f", tempProbe->getRunningAverage());
+  LiquidCrystal_TC::instance()->writeLine(output, 1);
 }

--- a/src/UIState/MainMenu.cpp
+++ b/src/UIState/MainMenu.cpp
@@ -15,8 +15,8 @@
 #include "SetTankID.h"
 #include "SetTempSetPoint.h"
 #include "SetTime.h"
-#include "TemperatureCalibration.h"
 #include "TempProbe_TC.h"
+#include "TemperatureCalibration.h"
 
 /**
  * Branch to other states to handle various menu options
@@ -24,52 +24,52 @@
 void MainMenu::handleKey(char key) {
   switch (key) {
     case 'A':  // Set pH set_point
-      this->setNextState((UIState*)new SetPHSetPoint(tc));
+      this->setNextState((UIState *)new SetPHSetPoint(tc));
       break;
     case 'B':  // Set Temperature set_point
-      this->setNextState((UIState*)new SetTempSetPoint(tc));
+      this->setNextState((UIState *)new SetTempSetPoint(tc));
       break;
     case 'C':  // pH Calibration
-      this->setNextState((UIState*)new PHCalibration(tc));
+      this->setNextState((UIState *)new PHCalibration(tc));
       break;
     case 'D':  // Calibration Management
-      this->setNextState((UIState*)new CalibrationManagement(tc));
+      this->setNextState((UIState *)new CalibrationManagement(tc));
       break;
     case '#':  // Set Tank ID
-      this->setNextState((UIState*)new SetTankID(tc));
+      this->setNextState((UIState *)new SetTankID(tc));
       break;
     case '*':  // Set Google Sheet Interval
-      this->setNextState((UIState*)new SetGoogleSheetInterval(tc));
+      this->setNextState((UIState *)new SetGoogleSheetInterval(tc));
       break;
     case '0':  // See Device Uptime & Current Time
-      this->setNextState((UIState*)new SeeDeviceUptime(tc));
+      this->setNextState((UIState *)new SeeDeviceUptime(tc));
       break;
     case '1':  // See Device addresses
-      this->setNextState((UIState*)new SeeDeviceAddress(tc));
+      this->setNextState((UIState *)new SeeDeviceAddress(tc));
       break;
     case '2':  // Reset LCD Screen
-      this->setNextState((UIState*)new ResetLCDScreen(tc));
+      this->setNextState((UIState *)new ResetLCDScreen(tc));
       break;
     case '3':  // See Tank ID and Log File Name
-      this->setNextState((UIState*)new SeeTankID(tc));
+      this->setNextState((UIState *)new SeeTankID(tc));
       break;
     case '4':  // See PID Constants
-      this->setNextState((UIState*)new SeePIDConstants(tc));
+      this->setNextState((UIState *)new SeePIDConstants(tc));
       break;
     case '5':  // PID Tuning
-      this->setNextState((UIState*)new PIDTuningMenu(tc));
+      this->setNextState((UIState *)new PIDTuningMenu(tc));
       break;
     case '6':  // Temperature Calibration
-      this->setNextState((UIState*)new TemperatureCalibration(tc));
+      this->setNextState((UIState *)new TemperatureCalibration(tc));
       break;
     case '7':  // Manual Set Time
-      this->setNextState((UIState*)new SetTime(tc));
+      this->setNextState((UIState *)new SetTime(tc));
       break;
     case '8':  // Enable PID
-      this->setNextState((UIState*)new EnablePID(tc));
+      this->setNextState((UIState *)new EnablePID(tc));
       break;
     case '9':  // Set Chill or Heat
-      this->setNextState((UIState*)new SetChillOrHeat(tc));
+      this->setNextState((UIState *)new SetChillOrHeat(tc));
       break;
     default:
       returnToMainMenu();

--- a/src/UIState/MainMenu.h
+++ b/src/UIState/MainMenu.h
@@ -14,6 +14,9 @@ public:
   MainMenu(TankControllerLib* tc) : UIState(tc) {
   }
   void handleKey(char key);
+  String name() {
+    return "MainMenu";
+  }
   const char* prompt() {
     return "Main Menu       ";
   };

--- a/src/UIState/NumberCollectorState.h
+++ b/src/UIState/NumberCollectorState.h
@@ -39,6 +39,9 @@ public:
   void setValue(double value) {
     storedValue = value;
   }
+  String name() {
+    return "TestNumCollectorState";
+  }
   const char* prompt() {
     return "Test:";
   }

--- a/src/UIState/PHCalibration.h
+++ b/src/UIState/PHCalibration.h
@@ -11,6 +11,9 @@ public:
   PHCalibration(TankControllerLib* tc) : UIState(tc) {
   }
   void handleKey(char key);
+  String name() {
+    return "PHCalibration";
+  }
   const char* prompt() {
     return "pH-Calibration  ";
   };

--- a/src/UIState/PIDTuningMenu.h
+++ b/src/UIState/PIDTuningMenu.h
@@ -11,6 +11,9 @@ public:
   PIDTuningMenu(TankControllerLib* tc) : UIState(tc) {
   }
   void handleKey(char key);
+  String name() {
+    return "PIDTuningMenu";
+  }
   const char* prompt() {
     return "PID TUNING      ";
   };

--- a/src/UIState/ResetLCDScreen.h
+++ b/src/UIState/ResetLCDScreen.h
@@ -11,6 +11,9 @@ public:
   ResetLCDScreen(TankControllerLib* tc) : UIState(tc) {
   }
   void handleKey(char key);
+  String name() {
+    return "ResetLCDScreen";
+  }
   const char* prompt() {
     return "Clearing Screen ";
   };

--- a/src/UIState/SeeDeviceAddress.h
+++ b/src/UIState/SeeDeviceAddress.h
@@ -11,6 +11,9 @@ public:
   SeeDeviceAddress(TankControllerLib* tc) : UIState(tc) {
   }
   void handleKey(char key);
+  String name() {
+    return "SeeDeviceAddress";
+  }
   const char* prompt() {
     return "Device address  ";
   };

--- a/src/UIState/SeeDeviceUptime.h
+++ b/src/UIState/SeeDeviceUptime.h
@@ -10,5 +10,8 @@ class SeeDeviceUptime : public UIState {
 public:
   SeeDeviceUptime(TankControllerLib* tc) : UIState(tc) {
   }
+  String name() {
+    return "SeeDeviceUptime";
+  }
   void start();
 };

--- a/src/UIState/SeePIDConstants.h
+++ b/src/UIState/SeePIDConstants.h
@@ -11,6 +11,9 @@ public:
   SeePIDConstants(TankControllerLib* tc) : UIState(tc) {
   }
   void handleKey(char key);
+  String name() {
+    return "SeePIDConstants";
+  }
   const char* prompt() {
     return "PID Constants   ";
   };

--- a/src/UIState/SeeTankID.h
+++ b/src/UIState/SeeTankID.h
@@ -11,6 +11,9 @@ public:
   SeeTankID(TankControllerLib* tc) : UIState(tc) {
   }
   void handleKey(char key);
+  String name() {
+    return "SeeTankID";
+  }
   const char* prompt() {
     return "Tank ID=        ";
   };

--- a/src/UIState/SetChillOrHeat.h
+++ b/src/UIState/SetChillOrHeat.h
@@ -10,6 +10,9 @@ class SetChillOrHeat : public NumCollectorState {
 public:
   SetChillOrHeat(TankControllerLib* tc) : NumCollectorState(tc) {
   }
+  String name() {
+    return "SetChillOrHeat";
+  }
   const char* prompt() {
     return "1:Chill; 9:Heat ";
   };

--- a/src/UIState/SetGoogleSheetInterval.h
+++ b/src/UIState/SetGoogleSheetInterval.h
@@ -10,6 +10,9 @@ class SetGoogleSheetInterval : public NumCollectorState {
 public:
   SetGoogleSheetInterval(TankControllerLib* tc) : NumCollectorState(tc) {
   }
+  String name() {
+    return "SetGoogleSheetInterval";
+  }
   const char* prompt() {
     return "G Sheet Minutes ";
   };

--- a/src/UIState/SetPHSetPoint.h
+++ b/src/UIState/SetPHSetPoint.h
@@ -10,6 +10,9 @@ class SetPHSetPoint : public NumCollectorState {
 public:
   SetPHSetPoint(TankControllerLib* tc) : NumCollectorState(tc) {
   }
+  String name() {
+    return "SetPHSetPoint";
+  }
   const char* prompt() {
     return "Set pH Set Point";
   };

--- a/src/UIState/SetTankID.h
+++ b/src/UIState/SetTankID.h
@@ -10,6 +10,9 @@ class SetTankID : public NumCollectorState {
 public:
   SetTankID(TankControllerLib* tc) : NumCollectorState(tc) {
   }
+  String name() {
+    return "SetTankID";
+  }
   const char* prompt() {
     return "Set Tank ID#    ";
   };

--- a/src/UIState/SetTempSetPoint.h
+++ b/src/UIState/SetTempSetPoint.h
@@ -10,6 +10,9 @@ class SetTempSetPoint : public NumCollectorState {
 public:
   SetTempSetPoint(TankControllerLib* tc) : NumCollectorState(tc) {
   }
+  String name() {
+    return "SetTempSetPoint";
+  }
   const char* prompt() {
     return "Set Temperature ";
   };

--- a/src/UIState/SetTime.h
+++ b/src/UIState/SetTime.h
@@ -10,6 +10,9 @@ class SetTime : public NumCollectorState {
 public:
   SetTime(TankControllerLib* tc) : NumCollectorState(tc) {
   }
+  String name() {
+    return "SetTime";
+  }
   const char* prompt() {
     return prompts[subState];
   }

--- a/src/UIState/TemperatureCalibration.h
+++ b/src/UIState/TemperatureCalibration.h
@@ -11,6 +11,9 @@ public:
   TemperatureCalibration(TankControllerLib* tc) : UIState(tc) {
   }
   void handleKey(char key);
+  String name() {
+    return "TemperatureCalibration";
+  }
   const char* prompt() {
     return "Temp Calibration";
   };

--- a/src/UIState/UIState.h
+++ b/src/UIState/UIState.h
@@ -25,6 +25,7 @@ public:
   }
   virtual void loop() {
   }
+  virtual String name() = 0;
   virtual const char* prompt() {
     return "                ";
   }

--- a/src/UIState/Wait.h
+++ b/src/UIState/Wait.h
@@ -13,6 +13,9 @@ public:
   }
   // watch to see if enough time has passed
   void loop();
+  String name() {
+    return "Wait";
+  }
   // override to do nothing
   void start() {
   }

--- a/test/Blink.cpp
+++ b/test/Blink.cpp
@@ -6,25 +6,24 @@
 
 #include "TankControllerLib.h"
 
-#define LED_PIN 13
-
 GodmodeState* state = GODMODE();
-const int logSize = 10;
+const int LOG_SIZE = 10;
 struct {
   long time;
   bool value;
-} pinLog[logSize];
+} pinLog[LOG_SIZE];
 int logIndex = 0;
 bool overflowFlag = false;
+const int LED_PIN = 13;
 
 class BitCollector : public DataStreamObserver {
 public:
   BitCollector() : DataStreamObserver(false, false) {
   }
   virtual void onBit(bool aBit) {
-    if (logIndex < logSize) {
+    if (logIndex < LOG_SIZE) {
       pinLog[logIndex].time = micros();
-      pinLog[logIndex].value = state->digitalPin[LED_BUILTIN];
+      pinLog[logIndex].value = state->digitalPin[LED_PIN];
       // std::cout << logIndex << ":" << pinLog[logIndex].time << ":" << pinLog[logIndex].value << endl;
       logIndex++;
     } else {
@@ -41,30 +40,30 @@ unittest(loop) {
   BitCollector led;
   logIndex = 0;
   TankControllerLib* tank = TankControllerLib::instance();
-  state->digitalPin[LED_BUILTIN].addObserver("led", &led);
+  state->digitalPin[LED_PIN].addObserver("led", &led);
   tank->setup();
   state->resetClock();
   assertEqual(0, micros());
   tank->loop();
-  assertEqual(0, micros());
+  assertTrue(0 <= micros() && micros() <= 10000);
   delay(1000);
-  assertEqual(1000000, micros());
+  assertTrue(1000000 <= micros() && micros() <= 1100000);
   tank->loop();
   delay(1000);
   tank->loop();
   delay(1000);
   tank->loop();
   delay(1000);
-  state->digitalPin[LED_BUILTIN].removeObserver("led");
+  state->digitalPin[LED_PIN].removeObserver("led");
   assertFalse(overflowFlag);
   assertEqual(4, logIndex);
   assertEqual(0, pinLog[0].time);
   assertEqual(HIGH, pinLog[0].value);
-  assertEqual(1000000, pinLog[1].time);
+  assertTrue(1000000 <= pinLog[1].time && pinLog[1].time <= 1100000);
   assertEqual(LOW, pinLog[1].value);
-  assertEqual(2000000, pinLog[2].time);
+  assertTrue(2000000 <= pinLog[2].time && pinLog[2].time <= 2100000);
   assertEqual(HIGH, pinLog[2].value);
-  assertEqual(3000000, pinLog[3].time);
+  assertTrue(3000000 <= pinLog[3].time && pinLog[3].time <= 3100000);
   assertEqual(LOW, pinLog[3].value);
 }
 

--- a/test/Menu.cpp
+++ b/test/Menu.cpp
@@ -1,259 +1,145 @@
 #include <Arduino.h>
 #include <ArduinoUnitTests.h>
 
-#include "Devices/DateTime_TC.h"
-#include "Devices/Keypad_TC.h"
-#include "Devices/LiquidCrystal_TC.h"
+#include "DateTime_TC.h"
+#include "Keypad_TC.h"
+#include "LiquidCrystal_TC.h"
 #include "TankControllerLib.h"
+#include "TempProbe_TC.h"
+
+// globals for the singletons used in every test
+TankControllerLib* tc = TankControllerLib::instance();
+LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
+Keypad* keypad = Keypad_TC::instance()->_getPuppet();
+
+// reduce duplicate code and make it more explicit
+void enterKey(char key) {
+  keypad->push_back(key);
+  tc->loop();  // recognize and apply the key entry
+}
+
+unittest(MainMenu) {
+  TempProbe_TC::instance()->setTemperature(12.30);
+  assertEqual(" ONTHANK LAB", lc->getLines().at(0).substr(4));
+  enterKey('A');
+  enterKey('D');
+  assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("Temp=12.30      ", lc->getLines().at(1));
+}
 
 unittest(SetPHSetPoint) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
-  Keypad* keypad = Keypad_TC::instance()->_getPuppet();
-  std::vector<String> lines;
-  lines = lc->getLines();
-  assertEqual(" ONTHANK LAB", lc->getLines().at(0).substr(4));
-  keypad->push_back('A');
-  tc->loop();  // recognize and apply the key entry
+  enterKey('A');
   assertEqual("Set pH Set Point", lc->getLines().at(0));
-  keypad->push_back('D');  // Don't finish (cancel)
-  tc->loop();              // recognize and apply the key entry
-  lines = lc->getLines();
-  assertEqual("Main Menu       ", lc->getLines().at(0));
+  enterKey('D');
   assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SetTempSetPoint) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
-  Keypad* keypad = Keypad_TC::instance()->_getPuppet();
-  std::vector<String> lines;
-  keypad->push_back('B');
-  tc->loop();  // recognize and apply the key entry
+  enterKey('B');
   assertEqual("Set Temperature ", lc->getLines().at(0));
-  keypad->push_back('D');  // Don't finish (cancel)
-  tc->loop();              // recognize and apply the key entry
-  lines = lc->getLines();
-  assertEqual("Main Menu       ", lc->getLines().at(0));
+  enterKey('D');
   assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(PHCalibration) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
-  Keypad* keypad = Keypad_TC::instance()->_getPuppet();
-  std::vector<String> lines;
-  keypad->push_back('C');
-  tc->loop();  // recognize and apply the key entry
+  enterKey('C');
   assertEqual("pH-Calibration  ", lc->getLines().at(0));
-  keypad->push_back('D');  // Don't finish (cancel)
-  tc->loop();              // recognize and apply the key entry
-  lines = lc->getLines();
-  assertEqual("Main Menu       ", lc->getLines().at(0));
+  enterKey('D');
   assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(CalibrationManagement) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
-  Keypad* keypad = Keypad_TC::instance()->_getPuppet();
-  std::vector<String> lines;
-  keypad->push_back('D');
-  tc->loop();  // recognize and apply the key entry
+  enterKey('D');
   assertEqual("Cal Management  ", lc->getLines().at(0));
-  keypad->push_back('D');  // Don't finish (cancel)
-  tc->loop();              // recognize and apply the key entry
-  lines = lc->getLines();
-  assertEqual("Main Menu       ", lc->getLines().at(0));
+  enterKey('D');
   assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SetTankID) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
-  Keypad* keypad = Keypad_TC::instance()->_getPuppet();
-  std::vector<String> lines;
-  keypad->push_back('#');
-  tc->loop();  // recognize and apply the key entry
+  enterKey('#');
   assertEqual("Set Tank ID#    ", lc->getLines().at(0));
-  keypad->push_back('D');  // Don't finish (cancel)
-  tc->loop();              // recognize and apply the key entry
-  lines = lc->getLines();
-  assertEqual("Main Menu       ", lc->getLines().at(0));
+  enterKey('D');
   assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SetGoogleSheetInterval) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
-  Keypad* keypad = Keypad_TC::instance()->_getPuppet();
-  std::vector<String> lines;
-  keypad->push_back('*');
-  tc->loop();  // recognize and apply the key entry
+  enterKey('*');
   assertEqual("G Sheet Minutes ", lc->getLines().at(0));
-  keypad->push_back('D');  // Don't finish (cancel)
-  tc->loop();              // recognize and apply the key entry
-  lines = lc->getLines();
-  assertEqual("Main Menu       ", lc->getLines().at(0));
+  enterKey('D');
   assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SeeDeviceUptime) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
-  Keypad* keypad = Keypad_TC::instance()->_getPuppet();
-  std::vector<String> lines;
-  keypad->push_back('0');
-  tc->loop();  // transition into the SeeDeviceUptime state
-  lines = lc->getLines();
-  assertEqual(DateTime_TC::now().as16CharacterString(), lines[0].c_str());
+  enterKey('0');
+  assertEqual(DateTime_TC::now().as16CharacterString(), lc->getLines().at(0).c_str());
   tc->loop();  // transition into the Wait state
-  lines = lc->getLines();
-  assertEqual(DateTime_TC::now().as16CharacterString(), lines[0].c_str());
+  assertEqual(DateTime_TC::now().as16CharacterString(), lc->getLines().at(0).c_str());
   delay(1000);
   tc->loop();  // this will set MainMenu as the next state
   tc->loop();  // this will start MainMenu
-  lines = lc->getLines();
-  assertEqual("Main Menu       ", lc->getLines().at(0));
   assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SeeDeviceAddress) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
-  Keypad* keypad = Keypad_TC::instance()->_getPuppet();
-  std::vector<String> lines;
-  keypad->push_back('1');
-  tc->loop();  // recognize and apply the key entry
+  enterKey('1');
   assertEqual("Device address  ", lc->getLines().at(0));
-  keypad->push_back('D');  // Don't finish (cancel)
-  tc->loop();              // recognize and apply the key entry
-  delay(1000);
-  tc->loop();
-  lines = lc->getLines();
-  assertEqual("Main Menu       ", lc->getLines().at(0));
+  enterKey('D');
   assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(ResetLCDScreen) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
-  Keypad* keypad = Keypad_TC::instance()->_getPuppet();
-  std::vector<String> lines;
-  keypad->push_back('2');
-  tc->loop();  // recognize and apply the key entry
+  enterKey('2');
   assertEqual("Clearing Screen ", lc->getLines().at(0));
-  keypad->push_back('D');  // Don't finish (cancel)
-  tc->loop();              // recognize and apply the key entry
-  delay(1000);
-  tc->loop();
-  lines = lc->getLines();
-  assertEqual("Main Menu       ", lc->getLines().at(0));
+  enterKey('D');
   assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SeeTankID) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
-  Keypad* keypad = Keypad_TC::instance()->_getPuppet();
-  std::vector<String> lines;
-  keypad->push_back('3');
-  tc->loop();  // recognize and apply the key entry
+  enterKey('3');
   assertEqual("Tank ID=        ", lc->getLines().at(0));
-  keypad->push_back('D');  // Don't finish (cancel)
-  tc->loop();              // recognize and apply the key entry
-  lines = lc->getLines();
-  assertEqual("Main Menu       ", lc->getLines().at(0));
+  enterKey('D');
   assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SeePIDConstants) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
-  Keypad* keypad = Keypad_TC::instance()->_getPuppet();
-  std::vector<String> lines;
-  keypad->push_back('4');
-  tc->loop();  // recognize and apply the key entry
+  enterKey('4');
   assertEqual("PID Constants   ", lc->getLines().at(0));
-  keypad->push_back('D');  // Don't finish (cancel)
-  tc->loop();              // recognize and apply the key entry
-  lines = lc->getLines();
-  assertEqual("Main Menu       ", lc->getLines().at(0));
+  enterKey('D');
   assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(PIDTuningMenu) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
-  Keypad* keypad = Keypad_TC::instance()->_getPuppet();
-  std::vector<String> lines;
-  keypad->push_back('5');
-  tc->loop();  // recognize and apply the key entry
+  enterKey('5');
   assertEqual("PID TUNING      ", lc->getLines().at(0));
-  keypad->push_back('D');  // Don't finish (cancel)
-  tc->loop();              // recognize and apply the key entry
-  lines = lc->getLines();
-  assertEqual("Main Menu       ", lc->getLines().at(0));
+  enterKey('D');
   assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(TemperatureCalibration) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
-  Keypad* keypad = Keypad_TC::instance()->_getPuppet();
-  std::vector<String> lines;
-  keypad->push_back('6');
-  tc->loop();  // recognize and apply the key entry
+  enterKey('6');
   assertEqual("Temp Calibration", lc->getLines().at(0));
-  keypad->push_back('D');  // Don't finish (cancel)
-  tc->loop();              // recognize and apply the key entry
-  lines = lc->getLines();
-  assertEqual("Main Menu       ", lc->getLines().at(0));
+  enterKey('D');
   assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SetTime) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
-  Keypad* keypad = Keypad_TC::instance()->_getPuppet();
-  std::vector<String> lines;
-  keypad->push_back('7');
-  tc->loop();  // recognize and apply the key entry
+  enterKey('7');
   assertEqual("Set Year (YYYY):", lc->getLines().at(0));
-  keypad->push_back('D');  // Don't finish (cancel)
-  tc->loop();              // recognize and apply the key entry
-  lines = lc->getLines();
-  assertEqual("Main Menu       ", lc->getLines().at(0));
+  enterKey('D');
   assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(EnablePID) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
-  Keypad* keypad = Keypad_TC::instance()->_getPuppet();
-  std::vector<String> lines;
-  keypad->push_back('8');
-  tc->loop();  // recognize and apply the key entry
+  enterKey('8');
   assertEqual("Enable PID?     ", lc->getLines().at(0));
-  keypad->push_back('D');  // Don't finish (cancel)
-  tc->loop();              // recognize and apply the key entry
-  lines = lc->getLines();
-  assertEqual("Main Menu       ", lc->getLines().at(0));
+  enterKey('D');
   assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SetChillOrHeat) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  LiquidCrystal_TC* lc = LiquidCrystal_TC::instance();
-  Keypad* keypad = Keypad_TC::instance()->_getPuppet();
-  std::vector<String> lines;
-  keypad->push_back('9');
-  tc->loop();  // recognize and apply the key entry
+  enterKey('9');
   assertEqual("1:Chill; 9:Heat ", lc->getLines().at(0));
-  keypad->push_back('D');  // Don't finish (cancel)
-  tc->loop();              // recognize and apply the key entry
-  lines = lc->getLines();
-  assertEqual("Main Menu       ", lc->getLines().at(0));
+  enterKey('D');
   assertEqual("MainMenu", tc->stateName());
 }
 

--- a/test/Menu.cpp
+++ b/test/Menu.cpp
@@ -20,6 +20,7 @@ unittest(SetPHSetPoint) {
   tc->loop();              // recognize and apply the key entry
   lines = lc->getLines();
   assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SetTempSetPoint) {
@@ -34,6 +35,7 @@ unittest(SetTempSetPoint) {
   tc->loop();              // recognize and apply the key entry
   lines = lc->getLines();
   assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(PHCalibration) {
@@ -48,6 +50,7 @@ unittest(PHCalibration) {
   tc->loop();              // recognize and apply the key entry
   lines = lc->getLines();
   assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(CalibrationManagement) {
@@ -62,6 +65,7 @@ unittest(CalibrationManagement) {
   tc->loop();              // recognize and apply the key entry
   lines = lc->getLines();
   assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SetTankID) {
@@ -76,6 +80,7 @@ unittest(SetTankID) {
   tc->loop();              // recognize and apply the key entry
   lines = lc->getLines();
   assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SetGoogleSheetInterval) {
@@ -90,6 +95,7 @@ unittest(SetGoogleSheetInterval) {
   tc->loop();              // recognize and apply the key entry
   lines = lc->getLines();
   assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SeeDeviceUptime) {
@@ -109,6 +115,7 @@ unittest(SeeDeviceUptime) {
   tc->loop();  // this will start MainMenu
   lines = lc->getLines();
   assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SeeDeviceAddress) {
@@ -125,6 +132,7 @@ unittest(SeeDeviceAddress) {
   tc->loop();
   lines = lc->getLines();
   assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(ResetLCDScreen) {
@@ -141,6 +149,7 @@ unittest(ResetLCDScreen) {
   tc->loop();
   lines = lc->getLines();
   assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SeeTankID) {
@@ -155,6 +164,7 @@ unittest(SeeTankID) {
   tc->loop();              // recognize and apply the key entry
   lines = lc->getLines();
   assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SeePIDConstants) {
@@ -169,6 +179,7 @@ unittest(SeePIDConstants) {
   tc->loop();              // recognize and apply the key entry
   lines = lc->getLines();
   assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(PIDTuningMenu) {
@@ -183,6 +194,7 @@ unittest(PIDTuningMenu) {
   tc->loop();              // recognize and apply the key entry
   lines = lc->getLines();
   assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(TemperatureCalibration) {
@@ -197,6 +209,7 @@ unittest(TemperatureCalibration) {
   tc->loop();              // recognize and apply the key entry
   lines = lc->getLines();
   assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SetTime) {
@@ -211,6 +224,7 @@ unittest(SetTime) {
   tc->loop();              // recognize and apply the key entry
   lines = lc->getLines();
   assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(EnablePID) {
@@ -225,6 +239,7 @@ unittest(EnablePID) {
   tc->loop();              // recognize and apply the key entry
   lines = lc->getLines();
   assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(SetChillOrHeat) {
@@ -239,6 +254,7 @@ unittest(SetChillOrHeat) {
   tc->loop();              // recognize and apply the key entry
   lines = lc->getLines();
   assertEqual("Main Menu       ", lc->getLines().at(0));
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest_main()

--- a/test/SeeDeviceUptime.cpp
+++ b/test/SeeDeviceUptime.cpp
@@ -20,14 +20,14 @@ unittest(testWaitState) {
   assertEqual(DateTime_TC::now().as16CharacterString(), lines[0].c_str());
   assertEqual("Up d:01 02:03:04", lines[1]);
 
-  tc->loop(); // SeeDeviceUptime -> Wait
+  tc->loop();  // SeeDeviceUptime -> Wait
   assertEqual("Wait", tc->stateName());
   delay(900);
-  tc->loop(); // Are we done waiting? No!
+  tc->loop();  // Are we done waiting? No!
   assertEqual("Wait", tc->stateName());
   delay(100);
-  tc->loop(); // Wait nextState: MainMenu
-  tc->loop(); // Wait -> MainMenu
+  tc->loop();  // Wait nextState: MainMenu
+  tc->loop();  // Wait -> MainMenu
   // now we should be back to the main menu
   assertEqual("MainMenu", tc->stateName());
 }

--- a/test/SeeDeviceUptime.cpp
+++ b/test/SeeDeviceUptime.cpp
@@ -9,26 +9,27 @@
 #include "UIState/UIState.h"
 
 unittest(testWaitState) {
-  TankControllerLibTest tc;
+  TankControllerLib* tc = TankControllerLib::instance();
+  assertEqual("MainMenu", tc->stateName());
   delay(((((1 * 24 + 2) * 60) + 3) * 60 + 4) * 1000);  // 1 hr 2 minutes
-  SeeDeviceUptime* test = new SeeDeviceUptime(&tc);
-  tc.setNextState(test);
-  // uptime will be visible for one second while we are in Wait state
-  assertFalse(tc.isOnMainMenu());
+  SeeDeviceUptime* test = new SeeDeviceUptime(tc);
+  tc->setNextState(test, true);  // MainMenu -> SeeDeviceUptime nextState: Wait
+  assertEqual("SeeDeviceUptime", tc->stateName());
   // during the delay we showed the expected two lines
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual(DateTime_TC::now().as16CharacterString(), lines[0].c_str());
   assertEqual("Up d:01 02:03:04", lines[1]);
 
-  tc.loop();
-  assertFalse(tc.isOnMainMenu());
+  tc->loop(); // SeeDeviceUptime -> Wait
+  assertEqual("Wait", tc->stateName());
   delay(900);
-  tc.loop();
-  assertFalse(tc.isOnMainMenu());
+  tc->loop(); // Are we done waiting? No!
+  assertEqual("Wait", tc->stateName());
   delay(100);
-  tc.loop();
+  tc->loop(); // Wait nextState: MainMenu
+  tc->loop(); // Wait -> MainMenu
   // now we should be back to the main menu
-  assertTrue(tc.isOnMainMenu());
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest_main()

--- a/test/SetChillOrHeat.cpp
+++ b/test/SetChillOrHeat.cpp
@@ -41,9 +41,12 @@ unittest(switchToChill) {
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("Use chiller     ", lines[1]);
+  assertEqual("SetChillOrHeat", tc->stateName());
+  tc->loop();  // transition to Wait
   assertEqual("Wait", tc->stateName());
   delay(1000);
-  tc->loop();
+  tc->loop();  // queue MainMenu to be next
+  tc->loop();  // transition to MainMenu
   // now we should be back to the main menu
   assertEqual("MainMenu", tc->stateName());
 }

--- a/test/SetChillOrHeat.cpp
+++ b/test/SetChillOrHeat.cpp
@@ -41,11 +41,11 @@ unittest(switchToChill) {
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("Use chiller     ", lines[1]);
-  assertFalse(tc.isOnMainMenu());
+  assertEqual("Wait", tc->stateName());
   delay(1000);
   tc.loop();
   // now we should be back to the main menu
-  assertTrue(tc.isOnMainMenu());
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest_main()

--- a/test/SetChillOrHeat.cpp
+++ b/test/SetChillOrHeat.cpp
@@ -6,13 +6,6 @@
 #include "EEPROM_TC.h"
 #include "TankControllerLib.h"
 
-unittest(default) {
-  TankControllerLib* tc = TankControllerLib::instance();
-  SetChillOrHeat* test = new SetChillOrHeat(tc);
-  tc->setNextState(test, true);
-  assertTrue(EEPROM_TC::instance()->getHeat());
-}
-
 unittest(ignoreInvalidValues) {
   TankControllerLib* tc = TankControllerLib::instance();
   SetChillOrHeat* test = new SetChillOrHeat(tc);
@@ -20,6 +13,12 @@ unittest(ignoreInvalidValues) {
   assertTrue(EEPROM_TC::instance()->getHeat());
   test->setValue(2.0);
   assertTrue(EEPROM_TC::instance()->getHeat());
+  tc->loop();  // transition to Wait
+  delay(1000);
+  tc->loop();  // queue MainMenu to be next
+  tc->loop();  // transition to MainMenu
+  // now we should be back to the main menu
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(switchToHeat) {
@@ -29,6 +28,12 @@ unittest(switchToHeat) {
   EEPROM_TC::instance()->setHeat(false);
   test->setValue(9.0);
   assertTrue(EEPROM_TC::instance()->getHeat());
+  tc->loop();  // transition to Wait
+  delay(1000);
+  tc->loop();  // queue MainMenu to be next
+  tc->loop();  // transition to MainMenu
+  // now we should be back to the main menu
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest(switchToChill) {

--- a/test/SetChillOrHeat.cpp
+++ b/test/SetChillOrHeat.cpp
@@ -7,34 +7,34 @@
 #include "TankControllerLib.h"
 
 unittest(default) {
-  TankControllerLibTest tc;
-  SetChillOrHeat* test = new SetChillOrHeat(&tc);
-  tc.setNextState(test);
+  TankControllerLib* tc = TankControllerLib::instance();
+  SetChillOrHeat* test = new SetChillOrHeat(tc);
+  tc->setNextState(test, true);
   assertTrue(EEPROM_TC::instance()->getHeat());
 }
 
 unittest(ignoreInvalidValues) {
-  TankControllerLibTest tc;
-  SetChillOrHeat* test = new SetChillOrHeat(&tc);
-  tc.setNextState(test);
+  TankControllerLib* tc = TankControllerLib::instance();
+  SetChillOrHeat* test = new SetChillOrHeat(tc);
+  tc->setNextState(test, true);
   assertTrue(EEPROM_TC::instance()->getHeat());
   test->setValue(2.0);
   assertTrue(EEPROM_TC::instance()->getHeat());
 }
 
 unittest(switchToHeat) {
-  TankControllerLibTest tc;
-  SetChillOrHeat* test = new SetChillOrHeat(&tc);
-  tc.setNextState(test);
+  TankControllerLib* tc = TankControllerLib::instance();
+  SetChillOrHeat* test = new SetChillOrHeat(tc);
+  tc->setNextState(test, true);
   EEPROM_TC::instance()->setHeat(false);
   test->setValue(9.0);
   assertTrue(EEPROM_TC::instance()->getHeat());
 }
 
 unittest(switchToChill) {
-  TankControllerLibTest tc;
-  SetChillOrHeat* test = new SetChillOrHeat(&tc);
-  tc.setNextState(test);
+  TankControllerLib* tc = TankControllerLib::instance();
+  SetChillOrHeat* test = new SetChillOrHeat(tc);
+  tc->setNextState(test, true);
   EEPROM_TC::instance()->setHeat(true);
   test->setValue(1.0);
   assertFalse(EEPROM_TC::instance()->getHeat());
@@ -43,7 +43,7 @@ unittest(switchToChill) {
   assertEqual("Use chiller     ", lines[1]);
   assertEqual("Wait", tc->stateName());
   delay(1000);
-  tc.loop();
+  tc->loop();
   // now we should be back to the main menu
   assertEqual("MainMenu", tc->stateName());
 }

--- a/test/SetGoogleSheetInterval.cpp
+++ b/test/SetGoogleSheetInterval.cpp
@@ -7,9 +7,9 @@
 #include "TankControllerLib.h"
 
 unittest(test) {
-  TankControllerLibTest tc;
-  SetGoogleSheetInterval* test = new SetGoogleSheetInterval(&tc);
-  tc.setNextState(test);
+  TankControllerLib* tc = TankControllerLib::instance();
+  SetGoogleSheetInterval* test = new SetGoogleSheetInterval(tc);
+  tc->setNextState(test, true);
 
   // setValue
   test->setValue(30);
@@ -20,7 +20,7 @@ unittest(test) {
   assertEqual("New interval=30 ", lines[1]);
   assertEqual("Wait", tc->stateName());
   delay(1000);
-  tc.loop();
+  tc->loop();
   // now we should be back to the main menu
   assertEqual("MainMenu", tc->stateName());
 }

--- a/test/SetGoogleSheetInterval.cpp
+++ b/test/SetGoogleSheetInterval.cpp
@@ -18,11 +18,11 @@ unittest(test) {
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("New interval=30 ", lines[1]);
-  assertFalse(tc.isOnMainMenu());
+  assertEqual("Wait", tc->stateName());
   delay(1000);
   tc.loop();
   // now we should be back to the main menu
-  assertTrue(tc.isOnMainMenu());
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest_main()

--- a/test/SetGoogleSheetInterval.cpp
+++ b/test/SetGoogleSheetInterval.cpp
@@ -18,9 +18,12 @@ unittest(test) {
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("New interval=30 ", lines[1]);
+  assertEqual("SetGoogleSheetInterval", tc->stateName());
+  tc->loop();  // transition to Wait
   assertEqual("Wait", tc->stateName());
   delay(1000);
-  tc->loop();
+  tc->loop();  // queue MainMenu to be next
+  tc->loop();  // transition to MainMenu
   // now we should be back to the main menu
   assertEqual("MainMenu", tc->stateName());
 }

--- a/test/SetPHSetPoint.cpp
+++ b/test/SetPHSetPoint.cpp
@@ -18,11 +18,11 @@ unittest(test) {
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("New pH=7.1234   ", lines[1]);
-  assertFalse(tc.isOnMainMenu());
+  assertEqual("Wait", tc->stateName());
   delay(1000);
   tc.loop();
   // now we should be back to the main menu
-  assertTrue(tc.isOnMainMenu());
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest_main()

--- a/test/SetPHSetPoint.cpp
+++ b/test/SetPHSetPoint.cpp
@@ -18,9 +18,12 @@ unittest(test) {
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("New pH=7.1234   ", lines[1]);
+  assertEqual("SetPHSetPoint", tc->stateName());
+  tc->loop();  // transition to Wait
   assertEqual("Wait", tc->stateName());
   delay(1000);
-  tc->loop();
+  tc->loop();  // queue MainMenu to be next
+  tc->loop();  // transition to MainMenu
   // now we should be back to the main menu
   assertEqual("MainMenu", tc->stateName());
 }

--- a/test/SetPHSetPoint.cpp
+++ b/test/SetPHSetPoint.cpp
@@ -7,9 +7,9 @@
 #include "TankControllerLib.h"
 
 unittest(test) {
-  TankControllerLibTest tc;
-  SetPHSetPoint* test = new SetPHSetPoint(&tc);
-  tc.setNextState(test);
+  TankControllerLib* tc = TankControllerLib::instance();
+  SetPHSetPoint* test = new SetPHSetPoint(tc);
+  tc->setNextState(test, true);
 
   // setValue
   test->setValue(7.1234);
@@ -20,7 +20,7 @@ unittest(test) {
   assertEqual("New pH=7.1234   ", lines[1]);
   assertEqual("Wait", tc->stateName());
   delay(1000);
-  tc.loop();
+  tc->loop();
   // now we should be back to the main menu
   assertEqual("MainMenu", tc->stateName());
 }

--- a/test/SetTankID.cpp
+++ b/test/SetTankID.cpp
@@ -18,11 +18,11 @@ unittest(test) {
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("Tank ID = 12    ", lines[1]);
-  assertFalse(tc.isOnMainMenu());
+  assertEqual("Wait", tc->stateName());
   delay(1000);
   tc.loop();
   // now we should be back to the main menu
-  assertTrue(tc.isOnMainMenu());
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest_main()

--- a/test/SetTankID.cpp
+++ b/test/SetTankID.cpp
@@ -18,9 +18,12 @@ unittest(test) {
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("Tank ID = 12    ", lines[1]);
+  assertEqual("SetTankID", tc->stateName());
+  tc->loop();  // transition to Wait
   assertEqual("Wait", tc->stateName());
   delay(1000);
-  tc->loop();
+  tc->loop();  // queue MainMenu to be next
+  tc->loop();  // transition to MainMenu
   // now we should be back to the main menu
   assertEqual("MainMenu", tc->stateName());
 }

--- a/test/SetTankID.cpp
+++ b/test/SetTankID.cpp
@@ -7,9 +7,9 @@
 #include "TankControllerLib.h"
 
 unittest(test) {
-  TankControllerLibTest tc;
-  SetTankID* test = new SetTankID(&tc);
-  tc.setNextState(test);
+  TankControllerLib* tc = TankControllerLib::instance();
+  SetTankID* test = new SetTankID(tc);
+  tc->setNextState(test, true);
 
   // setValue
   test->setValue(12);
@@ -20,7 +20,7 @@ unittest(test) {
   assertEqual("Tank ID = 12    ", lines[1]);
   assertEqual("Wait", tc->stateName());
   delay(1000);
-  tc.loop();
+  tc->loop();
   // now we should be back to the main menu
   assertEqual("MainMenu", tc->stateName());
 }

--- a/test/SetTempSetPoint.cpp
+++ b/test/SetTempSetPoint.cpp
@@ -19,9 +19,12 @@ unittest(test) {
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("New Temp=50.05  ", lines[1]);
+  assertEqual("SetTempSetPoint", tc->stateName());
+  tc->loop();  // transition to Wait
   assertEqual("Wait", tc->stateName());
   delay(1000);
-  tc->loop();
+  tc->loop();  // queue MainMenu to be next
+  tc->loop();  // transition to MainMenu
   // now we should be back to the main menu
   assertEqual("MainMenu", tc->stateName());
 }

--- a/test/SetTempSetPoint.cpp
+++ b/test/SetTempSetPoint.cpp
@@ -18,11 +18,11 @@ unittest(test) {
   // during the delay we showed the new value
   std::vector<String> lines = LiquidCrystal_TC::instance()->getLines();
   assertEqual("New Temp=50.05  ", lines[1]);
-  assertFalse(tc.isOnMainMenu());
+  assertEqual("Wait", tc->stateName());
   delay(1000);
   tc.loop();
   // now we should be back to the main menu
-  assertTrue(tc.isOnMainMenu());
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest_main()

--- a/test/SetTempSetPoint.cpp
+++ b/test/SetTempSetPoint.cpp
@@ -7,9 +7,10 @@
 #include "TankControllerLib.h"
 
 unittest(test) {
-  TankControllerLibTest tc;
-  SetTempSetPoint* test = new SetTempSetPoint(&tc);
-  tc.setNextState(test);
+  TankControllerLib* tc = TankControllerLib::instance();
+  SetTempSetPoint* test = new SetTempSetPoint(tc);
+  assertEqual("MainMenu", tc->stateName());
+  tc->setNextState(test, true);
 
   // setValue
   test->setValue(50.05);
@@ -20,7 +21,7 @@ unittest(test) {
   assertEqual("New Temp=50.05  ", lines[1]);
   assertEqual("Wait", tc->stateName());
   delay(1000);
-  tc.loop();
+  tc->loop();
   // now we should be back to the main menu
   assertEqual("MainMenu", tc->stateName());
 }

--- a/test/SetTime.cpp
+++ b/test/SetTime.cpp
@@ -41,10 +41,12 @@ unittest(test) {
 
   // a year ago ensures that it precedes the compile time
   assertEqual("2020-03-18 13:15", DateTime_TC::now().as16CharacterString());
-
+  assertEqual("SetTime", tc->stateName());
+  tc->loop();  // transition to Wait
   assertEqual("Wait", tc->stateName());
   delay(1000);
-  tc->loop();
+  tc->loop();  // queue MainMenu to be next
+  tc->loop();  // transition to MainMenu
   // now we should be back to the main menu
   assertEqual("MainMenu", tc->stateName());
 }

--- a/test/SetTime.cpp
+++ b/test/SetTime.cpp
@@ -9,9 +9,9 @@
 
 unittest(test) {
   LiquidCrystal_TC* lcd = LiquidCrystal_TC::instance();
-  TankControllerLibTest tc;
-  SetTime* test = new SetTime(&tc);
-  tc.setNextState(test);
+  TankControllerLib* tc = TankControllerLib::instance();
+  SetTime* test = new SetTime(tc);
+  tc->setNextState(test, true);
 
   DateTime_TC now = DateTime_TC::now();
   // the default time is the code compile time
@@ -44,7 +44,7 @@ unittest(test) {
 
   assertEqual("Wait", tc->stateName());
   delay(1000);
-  tc.loop();
+  tc->loop();
   // now we should be back to the main menu
   assertEqual("MainMenu", tc->stateName());
 }

--- a/test/SetTime.cpp
+++ b/test/SetTime.cpp
@@ -42,11 +42,11 @@ unittest(test) {
   // a year ago ensures that it precedes the compile time
   assertEqual("2020-03-18 13:15", DateTime_TC::now().as16CharacterString());
 
-  assertFalse(tc.isOnMainMenu());
+  assertEqual("Wait", tc->stateName());
   delay(1000);
   tc.loop();
   // now we should be back to the main menu
-  assertTrue(tc.isOnMainMenu());
+  assertEqual("MainMenu", tc->stateName());
 }
 
 unittest_main()

--- a/test/TempProbe_TC_Test.cpp
+++ b/test/TempProbe_TC_Test.cpp
@@ -11,8 +11,8 @@ unittest(TempProbe_Test) {
   uint16_t testRTD = tempProbe->getResistance();
   assertEqual(0, testRTD);
 
-  // Test getTemperature()
-  float testTemp = tempProbe->getTemperature();
+  // Test getRawTemperature()
+  float testTemp = tempProbe->getRawTemperature();
   assertEqual(-242, (int)testTemp);
 
   // Test readFault()
@@ -28,23 +28,63 @@ unittest(TempProbe_Test) {
   float temp = 0.0;
   tempProbe->setTemperature(0);
   assertEqual(7621, tempProbe->getResistance());
-  temp = tempProbe->getTemperature();
+  temp = tempProbe->getRawTemperature();
   assertTrue(-0.1 < temp && temp < 0.1);
 
   tempProbe->setTemperature(10);
   assertEqual(7918, tempProbe->getResistance());
-  temp = tempProbe->getTemperature();
+  temp = tempProbe->getRawTemperature();
   assertTrue(9.9 < temp && temp < 10.1);
 
   tempProbe->setTemperature(90);
   assertEqual(10266, tempProbe->getResistance());
-  temp = tempProbe->getTemperature();
+  temp = tempProbe->getRawTemperature();
   assertTrue(89.9 < temp && temp < 90.1);
 
   tempProbe->setTemperature(100);
   assertEqual(10554, tempProbe->getResistance());
-  temp = tempProbe->getTemperature();
+  temp = tempProbe->getRawTemperature();
   assertTrue(99.9 < temp && temp < 100.1);
+}
+
+unittest(adjustment) {
+  TempProbe_TC* tempProbe = TempProbe_TC::instance();
+  tempProbe->setTemperature(10.0);
+  tempProbe->setCorrection(0.5);
+  double temp = tempProbe->getRunningAverage();
+  assertTrue(10.49 <= temp && temp <= 10.51);
+}
+
+unittest(runningAverage) {
+  TempProbe_TC* tempProbe = TempProbe_TC::instance();
+  tempProbe->setTemperature(10.0);
+  tempProbe->setCorrection(0.0);
+  for (int i = 0; i < 100; ++i) {
+    tempProbe->getRunningAverage();
+  }
+  double temp = tempProbe->getRunningAverage();
+  assertTrue(9.9 <= temp && temp <= 10.1);
+  tempProbe->setTemperature(20.0);
+  temp = tempProbe->getRunningAverage();
+  assertTrue(10.9 <= temp && temp <= 11.1);
+  temp = tempProbe->getRunningAverage();
+  assertTrue(11.9 <= temp && temp <= 12.1);
+  temp = tempProbe->getRunningAverage();
+  assertTrue(12.9 <= temp && temp <= 13.1);
+  temp = tempProbe->getRunningAverage();
+  assertTrue(13.9 <= temp && temp <= 14.1);
+  temp = tempProbe->getRunningAverage();
+  assertTrue(14.9 <= temp && temp <= 15.1);
+  temp = tempProbe->getRunningAverage();
+  assertTrue(15.9 <= temp && temp <= 16.1);
+  temp = tempProbe->getRunningAverage();
+  assertTrue(16.9 <= temp && temp <= 17.1);
+  temp = tempProbe->getRunningAverage();
+  assertTrue(17.9 <= temp && temp <= 18.1);
+  temp = tempProbe->getRunningAverage();
+  assertTrue(18.9 <= temp && temp <= 19.1);
+  temp = tempProbe->getRunningAverage();
+  assertTrue(19.9 <= temp && temp <= 20.1);
 }
 
 unittest_main()

--- a/test/TempProbe_TC_Test.cpp
+++ b/test/TempProbe_TC_Test.cpp
@@ -23,6 +23,28 @@ unittest(TempProbe_Test) {
   tempProbe->clearFault();
   testFault = tempProbe->readFault();
   assertEqual(0, testFault);
+
+  // Test setTemperature()
+  float temp = 0.0;
+  tempProbe->setTemperature(0);
+  assertEqual(7621, tempProbe->getResistance());
+  temp = tempProbe->getTemperature();
+  assertTrue(-0.1 < temp && temp < 0.1);
+
+  tempProbe->setTemperature(10);
+  assertEqual(7918, tempProbe->getResistance());
+  temp = tempProbe->getTemperature();
+  assertTrue(9.9 < temp && temp < 10.1);
+
+  tempProbe->setTemperature(90);
+  assertEqual(10266, tempProbe->getResistance());
+  temp = tempProbe->getTemperature();
+  assertTrue(89.9 < temp && temp < 90.1);
+
+  tempProbe->setTemperature(100);
+  assertEqual(10554, tempProbe->getResistance());
+  temp = tempProbe->getTemperature();
+  assertTrue(99.9 < temp && temp < 100.1);
 }
 
 unittest_main()


### PR DESCRIPTION
* Able to set temperature to be returned by mock temp probe.
* TempProbe supports running average.
* Replace `isMainMenu()` with `stateName()` to facilitate debugging.
* Remove testing subclass `TankControllerStateTest` and add option to `setNextState()` to advance immediately. 
* Add debugging logging (commented out). 
* Move method from .h to .cpp and sort functions by name.
* Refactor MainMenu and simplify test.
* Fix transitions through Wait back to MainMenu.